### PR TITLE
fix for riceathon's count

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -115,7 +115,7 @@ limitedTime:
   slackChannel: "#riceathon"
   status: active
   deadline: '2025-01-10T23:59:59'
-  participants: 1
+  participants: 64
 - name: Hacky Holidays
   description: Design a PCB holiday decoration this winter, get one shipped.
   website: https://hacky-holidays.hackclub.com/


### PR DESCRIPTION
this is unrelated to neon's PR, this just updates the current participants(sourced from members.json)