### PR TITLE
Update Hacky Holidays deadline

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -122,7 +122,7 @@ limitedTime:
   slack: https://hackclub.slack.com/archives/C083SK3G5D3
   slackChannel: "#hacky-holidays"
   status: active
-  deadline: '2025-01-15T23:59:59'
+  deadline: '2025-01-30T23:59:59'
 - name: Say Cheese!
   description: Fit a program in a QR code, get a portable printer and maybe a Blåhaj.
   detailedDescription: Fit a program inside a QR code, and get a potentially cat-themed


### PR DESCRIPTION
Hacky Holidays has been extended to January 30th ([Slack Link](https://hackclub.slack.com/archives/C083SK3G5D3/p1735596521644479?thread_ts=1735590940.607959&cid=C083SK3G5D3))