### PR TITLE
Mark OnBoard as ended

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -221,8 +221,8 @@ indefinite:
   website: https://hackclub.com/onboard
   slack: https://hackclub.slack.com/archives/C056AMWSFKJ
   slackChannel: "#electronics"
-  status: active
-  participants: 604
+  status: ended
+  participants: 1000
 - name: Boba Drops
   description: Build a website and get boba!
   website: https://boba.hackclub.com/


### PR DESCRIPTION
Onboard has ended because it has reached 1000 grants, so I marked it as ended