### PR TITLE
Move Neighborhood to ended

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -323,8 +323,8 @@ limitedTime:
   website: https://neighborhood.hackclub.com
   slack: https://hackclub.slack.com/archives/C073L9LB4K1
   slackChannel: "#neighborhood"
-  status: active
-  deadline: '2025-08-31T23:59:59'
+  status: ended
+  # deadline: '2025-08-31T23:59:59' # Neighborhood was ended early
 indefinite:
 - name: Sprig
   description: Build a JS game and play it on your own console.


### PR DESCRIPTION
Neighborhood was unfortunately [ended early](https://hackclub.slack.com/archives/C073L9LB4K1/p1752110716576469) so its status should be changed to `ended`.