### PR TITLE
Change Axiom YSWS to the new `.hackclub.com` domain

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -778,7 +778,7 @@ indefinite:
 drafts:
 - name: Axiom
   description: YSWS for math/science projects!
-  website: https://itmzetanjim.github.io/axiom/
+  website: https://axiom.hackclub.com/
   slack: https://hackclub.slack.com/archives/C09K4HZJ2DP
   slackChannel: "#axiom"
   status: draft


### PR DESCRIPTION
https://axiom.hackclub.com is the new domain since we now have a sponsor (@gusruben or `@augie` in slack)