### PR TITLE
Add Fudge

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -2,7 +2,7 @@
 limitedTime:
 - name: Fudge
   description: Make any project you want, get fudge right from the Shelburne County Store next to HQ!
-  website: https://5.hackclub.com
+  website: https://fudge.hackclub.com
   slack: https://hackclub.enterprise.slack.com/archives/C09UZPNGMMM
   slackChannel: "#fudge-fudge-fudge"
   status: active


### PR DESCRIPTION
Adding the Fudge YSWS.

Most of the additional data was sourced from
https://hackclub.slack.com/archives/C09UZPNGMMM/p1764864924037499 other
than the
[deadline](https://hackclub.slack.com/archives/C09UZPNGMMM/p1764864924037499).

The website currently states that a full pound of fudge is 5 hours, but
a [clarification on
Slack](https://hackclub.slack.com/archives/C09UZPNGMMM/p1764864924037499)
updated it to 6 hours. I created a pull request (https://github.com/hackclub/fudge/pull/2),
updating it.