### PR TITLE
Move Woof to active programs

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -59,7 +59,7 @@ limitedTime:
    - Your project has to be related to dogs
    - You must track code time with Hackatime and push to GitHub
    - Your project has to be made by you 🫵
-   - You need a demo link for your project (URL, downloadbale executable or fully built for hardware)
+   - You need a demo link for your project (URL, downloadable executable or fully built for hardware)
    - US participants receive physical plushie (shipped to address), international participants receive $25 in HCB grant cards to buy their plushie.
 - name: Bauble
   description: 3D model an ornament, get it printed and put on the HQ tree! Ends December 25th.


### PR DESCRIPTION
- Moves Woof to active programs
- Changes URL to be https://woof.hackclub.com
- Adds end date, detailed descripton steps & details
- Adds Active status

