### PR TITLE
[small fix]dark mode  in forge description text

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4626,6 +4626,11 @@ overflow: hidden;
   color: white !important;
   animation: forge-status-glow 2s ease-in-out infinite !important;
 }
+.program-card.forge-card p,
+.program-card.forge-card .program-participants {
+  color: #e6eef9 !important;
+}
+
 @keyframes forge-status-glow {
   0%,
   100% {


### PR DESCRIPTION
we changed text color to sync it with both dark and light mode sry for another pull request we didn't see it coming