### PR TITLE
Cleanup of Draft YSWS and Addition of Deadlines for YSWS with deadlines

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -19,6 +19,8 @@ limitedTime:
     website: https://macondo.hackclub.com/?utm_source=ysws-catalog
     slack: https://hackclub.enterprise.slack.com/archives/C0AUZ1LAMH6
     slackChannel: "#macondo"
+    deadline: 2026-09
+
     status: active
   - name: Horizons
     description: 7 hackathons. Run by teenagers across the globe. For teenagers everywhere.
@@ -26,6 +28,8 @@ limitedTime:
     slack: https://hackclub.enterprise.slack.com/archives/C0AGKQ6K476
     slackChannel: "#horizons"
     status: active
+    deadline: "2026-08-14"
+
   - name: Fix Hack Club
     description: Contribute to Hack Club repositories, get a grant of your choice!
     website: https://fix.hackclub.com/
@@ -45,6 +49,7 @@ limitedTime:
     slack: https://hackclub.enterprise.slack.com/archives/C0ALJ3NT1D0
     slackChannel: "#beest"
     status: active
+    deadline: 2026-09
   - name: RaspAPI
     description: Build an API, get a Raspberry Pi Zero 2W to host it on!
     detailedDescription: RaspAPI is a Hack Club YSWS where you build an original, publicly accessible API using any language or framework, log your hours with Hackatime, and earn a Raspberry Pi Zero 2W to host it on. Your API needs at least 3 GET and 1 POST endpoint, docs at /docs, and a public git repo with a README. Reviewers award multipliers based on what your API implements, so the more creative and complex, the better!
@@ -70,20 +75,20 @@ limitedTime:
     website: https://flavortown.hackclub.com/?ref=ysws-catalog
     slack: https://hackclub.enterprise.slack.com/archives/C09MPB8NE8H
     slackChannel: "#flavortown"
-    status: active
+    status: ended
   - name: Sleepover
     deadline: "2026-05-01T00:00:00.000Z"
     description: Learn to code and fly to an all girls slumber party hackathon!
     website: https://sleepover.hackclub.com/?utm_source=ysws-catalog
     slack: https://hackclub.enterprise.slack.com/archives/C0A9UNRF96V
     slackChannel: "#athena-sleepover"
-    status: active
+    status: ended
   - name: Construct
     description: "Design projects using CAD, Get a 3d printer to print them!"
     website: https://construct.hackclub.com
     slack: https://hackclub.enterprise.slack.com/archives/C09TM7XKSSY
     slackChannel: "#construct"
-    status: active
+    status: ended
     deadline: 2026-04-19
     steps:
       - Log into construct.hackclub.com
@@ -96,20 +101,15 @@ limitedTime:
     website: https://trailit.hackclub.com
     slack: https://hackclub.enterprise.slack.com/archives/C0AGG8J6PLL
     slackChannel: "#trailit-ysws"
-    status: active
+    status: ended
   - name: Remixed
-    deadline: 2026-04-30
+    deadline: 2026-06-12
     description: Ship something music related, get stuff to help you make music!
     website: https://remixed.hackclub.com/?ref=ysws-catalog
     slack: https://hackclub.enterprise.slack.com/archives/C0AK823BZM0
     slackChannel: "#remixed-bulletin"
     status: active
-  - name: Enclosure
-    description: Design a custom enclosure for your project, get a 3D print of it shipped to you and tier based prizes!
-    website: https://enclosure.hackclub.com/
-    slack: https://hackclub.enterprise.slack.com/archives/C092D99G1RU
-    slackChannel: "#enclosure"
-    status: active
+
   - name: Stasis
     deadline: "2026-05-18T00:00:00.000Z"
     description: Build hardware projects and fly to a hardware hackathon in Austin, Texas
@@ -1059,9 +1059,22 @@ limitedTime:
     slack: https://hackclub.slack.com/archives/C073L9LB4K1
     slackChannel: "#neighborhood"
     status: ended
+  - name: Carnival
+    description: Build an extension, plugin, or widget get prizes
+    website: https://carnival.hackclub.com/
+    slack: https://hackclub.slack.com/archives/C091ZRTMF16
+    slackChannel: "#carnival"
+    deadline: 2026-05-31
+    status: active 
     # deadline: '2025-08-31T23:59:59' # Neighborhood was ended early
 
 recentlyEnded:
+  - name: Hackducky
+    description: Create A DuckyScript get a Rubber Ducky ! ( hackducky )
+    website:
+    slack: https://hackclub.slack.com/archives/C08B8HZBC85
+    slackChannel: "#hackducky"
+    status: ended
   - name: Armed
     description: Develop an arm assembly program, get lego.
     website: https://armed.hackclub.com
@@ -1099,6 +1112,12 @@ recentlyEnded:
     deadline: "2025-06-30T23:59:59"
 
 indefinite:
+  - name: Enclosure
+    description: Design a custom enclosure for your project, get a 3D print of it shipped to you and tier based prizes!
+    website: https://enclosure.hackclub.com/
+    slack: https://hackclub.enterprise.slack.com/archives/C092D99G1RU
+    slackChannel: "#enclosure"
+    status: active
   - name: iplace
     description: A collaborative canvas of websites, made by Hack Clubbers! Get hosting and domain credits!
     website: https://iplace.hackclub.com/?utm_source=ysws-catalog
@@ -1117,12 +1136,7 @@ indefinite:
     slack: https://hackclub.slack.com/archives/C0ARNAJH971
     slackChannel: "#syscall-ysws"
     status: active
-  - name: Carnival
-    description: Build an extension, plugin, or widget get prizes
-    website: https://carnival.hackclub.com/
-    slack: https://hackclub.slack.com/archives/C091ZRTMF16
-    slackChannel: "#carnival"
-    status: active 
+
   - name: Sprig
     description: Build a JS game and play it on your own console.
     website: https://sprig.hackclub.com/
@@ -1229,24 +1243,13 @@ drafts:
       - Improve your skills as you navigate through increasingly difficult rooms.
       - Complete your path and receive TryHackMe Premium plus access to the Shop.
       - Conquer difficult rooms, collect coins, and redeem them for cool prizes in the Shop.
-  - name: Track it
-    description: Build a map app, GeoGuessr-style game, or GPS tracker. Explore the world. Win prizes.
-    slack: https://hackclub.enterprise.slack.com/archives/C0ADWJB6QT0
-    slackChannel: "#track-it"
-    website: https://trackit-ysws.vercel.app/
-    status: draft
+
   - name: Kit Lab
     description: Build software according to themes and gets kits to build projects and ship projects made using only the kit electronics and get prizes!
     slack: https://hackclub.enterprise.slack.com/archives/C0AAM3UH8KC
     slackChannel: "#kit-lab"
     status: draft
-  - name: Rooted
-    description: Spend time coding, come to BornHack 🏕️ ∣ RSVP
-    detailedDescription: Spend time on projects and get a ticket to come to Hack Clubs site at BornHack! STILL A WIP, RSVP NOW!
-    website: https://rooted.hackclub.com/
-    slack: https://hackclub.enterprise.slack.com/archives/C09LYU1S23Y
-    slackChannel: "#rooted"
-    status: draft
+
   - name: MakerCreate
     description: Spawn into a world of hardware and CAD modelling with MakerCreate
     detailedDescription: MakerCreate is a YSWS (You Ship, We Ship) program @ HackClub. You spend time designing hardware or CAD projects on an editor of your choice, and we ship you a 3D printer of your choice! You can alternatively choose to buy parts or upgrades via our very own shop (pretty cool huh 🎃?)
@@ -1272,76 +1275,18 @@ drafts:
     slack: https://hackclub.slack.com/archives/C09C9M0N2UC
     slackChannel: "#issued"
     status: draft
-  - name: Swatchbox
-    description: You ship a modular art component, we ship the swatchbox to go with it!
-    website:
-    slack: https://hackclub.slack.com/archives/C094R49MS9Y
-    slackChannel: "#swatchbox"
-    status: draft
-  - name: Rube Goldburg YSWS
-    description: Create complex chain reaction machines and contraptions
-    website:
-    slack: https://hackclub.slack.com/archives/C094U05FAE6
-    slackChannel: "#rube-goldberg-ysws"
-    status: draft
-  - name: Poetry
-    description: "You ship: poetry (details to be decided soon) We ship: Maybe a poster or smth?"
-    website:
-    slack: https://hackclub.slack.com/archives/C095DDUVCJX
-    slackChannel: "#poetry-ysws"
-    status: draft
-  - name: Plunge
-    description: DESIGN A PLUNGER-STYLE COOKIE CUTTER, GET IT SHIPPED!
-    website: http://plunge.hackclub.com/
-    slack: https://hackclub.slack.com/archives/C0955KVD1SA
-    slackChannel: "#plunge"
-    status: draft
-  - name: Aquarium
-    description: Build aquatic-themed projects and digital ecosystems
-    website:
-    slack: https://hackclub.slack.com/archives/C095PTABEJK
-    slackChannel: "#aquarium"
-    status: draft
+
+
+
   - name: Apogee
     description: a rocketry ysws - still workshopping the idea!
     website:
     slack: https://hackclub.slack.com/archives/C095RKGV5J4
     slackChannel: "#apogee"
     status: draft
-  - name: Glossarium
-    description: You ship anything that can provide knowledge (a comic, a tutorial, a how-to...) We ship a zine from Julia Evans
-    website: https://mathiasdpx.github.io/glossarium/
-    slack: https://hackclub.slack.com/archives/C096L6J19PY
-    slackChannel: "#glossarium"
-    status: draft
-  - name: Hack A Home
-    description: You Ship a Home Assistant with Software,PCB and Case, We Ship a grant ($150 Max)to make it.
-    detailedDescription: |
-      Build a home assistant with Software,PCB and Case . We will send u a grant ($150 Max)to make it.
-    website:
-    slack: https://hackclub.slack.com/archives/C08N4UN6AUS
-    slackChannel: "#hack-a-home"
-    status: draft
-  - name: Hackumentary
-    description: You Ship a project with dev vlogs, We Ship points through which you can buy goodies
-    detailedDescription: |
-      Build a project with daily dev vlogs, we ship you points for every dev vlog you create, which you can use to purchase exciting goodies after shipping your project
-    website:
-    slack: https://hackclub.slack.com/archives/C08NH401M2S
-    slackChannel: "#hackumentary"
-    status: draft
-  - name: Reef
-    description: Ship a deep learning project (AI/ML/LLM/NN), get a custom coral based accelerator.
-    website:
-    slack: https://hackclub.slack.com/archives/C08K33ZUUR5
-    slackChannel: "#reef"
-    status: draft
-  - name: Hackducky
-    description: Create A DuckyScript get a Rubber Ducky ! ( hackducky )
-    website:
-    slack: https://hackclub.slack.com/archives/C08B8HZBC85
-    slackChannel: "#hackducky"
-    status: draft
+
+
+
   - name: Servo
     description: Design upgrades for your robot, get parts & prizes!
     website: https://servo-ysws.netlify.app/
@@ -1354,49 +1299,16 @@ drafts:
     slack: https://hackclub.slack.com/archives/C089WSLC59V
     slackChannel: "#hack-a-band"
     status: draft
-  - name: Vine
-    description: Create a song using open-source music software and receive a vinyl with your song.
-    website: https://vineysws.vercel.app/
-    slack: https://hackclub.slack.com/archives/C07N0VA3YGJ
-    slackChannel: "#vine-ysws"
-    status: draft
-  - name: Hack Store
-    description: Use a free alternative app store and get a Google Developer account.
-    website: https://www.hackstore.dev/
-    slack: https://hackclub.slack.com/archives/C07BGFG6CDQ
-    slackChannel: "#hack-store"
-    status: draft
-  - name: Light Up
-    description: Design an electronic circuit with lights, and Hack Club sends you the components and gifts.
-    website:
-    slack: https://hackclub.slack.com/archives/C07RNEJ13LJ
-    slackChannel: "#lightup-ysws"
-    status: draft
-  - name: Aether
-    description: Build a Windows app, and Hack Club provides a Microsoft Store developer account.
-    website:
-    slack: https://hackclub.slack.com/archives/C07V78URSGL
-    slackChannel: "#aether-ysws"
-    status: draft
+
+
+
   - name: Onward
     description: Build a robot using Arduino and receive one.
     website:
     slack: https://hackclub.slack.com/archives/C079G5MKC93
     slackChannel: "#onward"
     status: draft
-  - name: PicoJam
-    description: Create a PICO-8 game, get a PICO-8 license for free!
-    detailedDescription: Use PICO-8 Education Edition to build a game with your own assets (art, sound effects, etc). Your game should have a basic goal and at least 2 minutes of gameplay. The top winner will receive a Physical PICO-8 Emulator Device!
-    website:
-    slack: https://hackclub.slack.com/archives/C08CLJ29RA9
-    slackChannel: "#picojam"
-    status: draft
-  - name: Hack the Line
-    description: Get an Asterisk server running, and we'll send you a VoIP phone.
-    website:
-    slack: https://hackclub.slack.com/archives/C08B6PHLADU
-    slackChannel: "#hacktheline"
-    status: draft
+
   - name: Constellation
     description: You ship a self host, full stack website, we ship a Raspberry Pi Zero 2 W to host it on
     website:
@@ -1422,77 +1334,24 @@ drafts:
     slackChannel: "#jetsu"
     status: draft
     deadline: "2025-07-31T23:59:59"
-  - name: Hackclub market
-    description: You can buy/sell pcb's online
-    website: https://market.hackclub.com
-    slack: https://app.slack.com/client/T0266FRGM/C089VQAULJ0
-    slackChannel: "#hack-club-market"
-    status: draft
+  
   - name: Lightsaber
     description: You ship a beat saber map, we ship a(n) <undecided>.
     website:
     slack: https://slack.com/archives/C08C8PC40BA
     slackChannel: "#lightsaber"
-  - name: Turquoise
-    description: You ship a linux distro, we ship a custom Hack Club skirt
-    website:
-    slack: https://slack.com/archives/C08BAEP4SCX
-    slackChannel: "#turquoise"
-    status: draft
-  - name: Wetube
-    description: You ship a YouTube channel, we ship points for every video to spend on video equipment!
-    website: https://wetubeysws.vercel.app/
-    slack: https://slack.com/archives/C07U8QM9MEF
-    slackChannel: "#wetube"
-    status: draft
-  - name: Mini MIDI Magic
-    description: You ship a custom MIDI Synth/Controller with the firmware, we make it and send it to you!
-    website:
-    slack: https://slack.com/archives/C081ZV47Z8D
-    slackChannel: "#mini-midi-magic"
-    status: draft
-  - name: Glyphic
-    description: You Ship a cool and advanced Manim animation visualizing something, We Ship a Lamy Safari Fountain Pen
-    website:
-    slack: https://slack.com/archives/C087E2VDBL3
-    slackChannel: "#glyphic"
-    status: draft
-  - name: Pridehaj
-    description: You ship a pride themed website, we ship a blahaj
-    website:
-    slack: https://slack.com/archives/C08BL0ELHLJ
-    slackChannel: "#pridehaj"
-    status: draft
-  - name: Hack Drive
-    description: You Ship a cool filesystem/something using FUSE, We Ship a Hack Club branded flash drive
-    website: https://hackdrive.radi8.dev/
-    slack: https://slack.com/archives/C08EDPJ544E
-    slackChannel: "#hackdrive-ysws"
-    status: draft
+
+
+
   - name: Hackmouse
     description: Design a PCB & case for a mouse and get the parts shipped to you.
     website:
     slack: https://slack.com/archives/C08JYC7RQT1
     slackChannel: "#hackmouse"
     status: draft
-  - name: The Ride
-    description: You ship a PCB to go on an adventure, we give you the opportunity to build an (offroad) bike at HQ and go on that adventure.
-    website:
-    slack: https://slack.com/archives/C08L5UZTH0X
-    slackChannel: "#the-ride"
-    status: draft
-  - name: Trainix
-    description: Build an RL model for math problems and win an ESP32-S3 + OLED Module. Top 3 get an NVIDIA Jetson Orin Nano Developer Kit.
-    website:
-    slack: https://hackclub.slack.com/archives/C08M1F3DYSE
-    slackChannel: "#trainix"
-    status: draft
-  - name: RPG
-    description: Work together with other hack clubbers to fight bosses and earn awesome loot and an exclusive trading card for those who help defeat each boss!
-    website: https://rpg.hackclub.com/
-    slack: https://slack.com/archives/C08JCNN7C59
-    slackChannel: "#rpg"
-    status: draft
+
+  
+
   - name: Pyramid Scheme
     description: Put up Hack Club posters to earn prizes.
     website:
@@ -1628,12 +1487,7 @@ drafts:
     slackChannel: "#boba"
     status: ended
     ended: "2024-12-31T23:59:59"
-  - name: The hackbook
-    description: Write segments on almost anything, get the hackbook shipped to you and win prizes!
-    slack: https://hackclub.enterprise.slack.com/archives/C0AF24QR8KY
-    slackchannel: #the-hackbook
-    status: draft
-    website: https://hackbook.fillout.com/rsvp
+ 
   - name: Rework
     description: CAD a 3d printer mod, get $75 and 1kg of Hack Club filament to build it!
     slack: https://hackclub.enterprise.slack.com/archives/C0A5Q3L91U3


### PR DESCRIPTION
This pull request is meant to remove any ysws draft in the site which has either
- An Archived channel
- Not Atleast 4 real messages after 10th of March
- NOTE: The real messages don't include messages like "Is this alive?" or "Is this happening"

This pull request also adds end dates to few limited time ysws with missing end dates
- Carnival had its exact end date added
- Beest and Macondo has september as their end date as both say they will end on "Late August"
- Horizons has 14th July as its end date(The last date of last horzion, horizion equinox)