### PR TITLE
Making ysws.hackclub.com fit with the new site design!!

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,12 +206,13 @@
             <a href="#programs-list" class="cta-button">Explore Programs<span class="button-arrow">→</span></a>
         </div>
 
-        <!-- Mountain-bump wave divider — echoes the new hackclub.com landing page -->
-        <div class="wave-divider" aria-hidden="true" style="position:absolute;bottom:-1px;left:0;right:0;">
+        <!-- Mountain-bump wave divider — echoes the new hackclub.com landing page.
+             CSS variables don't resolve in raw SVG attribute values, so the path
+             fill is set via the `.wave-divider svg path` rule in styles.css. -->
+        <div class="wave-divider hero-wave" aria-hidden="true">
             <svg viewBox="0 0 1920 40" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
                 <path
-                    d="M0,40 L0,27 C40,27 40,8 80,8 C120,8 120,27 160,27 C200,27 200,8 240,8 C280,8 280,27 320,27 C360,27 360,8 400,8 C440,8 440,27 480,27 C520,27 520,8 560,8 C600,8 600,27 640,27 C680,27 680,8 720,8 C760,8 760,27 800,27 C840,27 840,8 880,8 C920,8 920,27 960,27 C1000,27 1000,8 1040,8 C1080,8 1080,27 1120,27 C1160,27 1160,8 1200,8 C1240,8 1240,27 1280,27 C1320,27 1320,8 1360,8 C1400,8 1400,27 1440,27 C1480,27 1480,8 1520,8 C1560,8 1560,27 1600,27 C1640,27 1640,8 1680,8 C1720,8 1720,27 1760,27 C1800,27 1800,8 1840,8 C1880,8 1880,27 1920,27 L1920,40 Z"
-                    fill="var(--background)" />
+                    d="M0,40 L0,27 C40,27 40,8 80,8 C120,8 120,27 160,27 C200,27 200,8 240,8 C280,8 280,27 320,27 C360,27 360,8 400,8 C440,8 440,27 480,27 C520,27 520,8 560,8 C600,8 600,27 640,27 C680,27 680,8 720,8 C760,8 760,27 800,27 C840,27 840,8 880,8 C920,8 920,27 960,27 C1000,27 1000,8 1040,8 C1080,8 1080,27 1120,27 C1160,27 1160,8 1200,8 C1240,8 1240,27 1280,27 C1320,27 1320,8 1360,8 C1400,8 1400,27 1440,27 C1480,27 1480,8 1520,8 C1560,8 1560,27 1600,27 C1640,27 1640,8 1680,8 C1720,8 1720,27 1760,27 C1800,27 1800,8 1840,8 C1880,8 1880,27 1920,27 L1920,40 Z" />
             </svg>
         </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -120,21 +120,14 @@
     <title>Hack Club YSWS Programs</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800;900&display=swap"
-        rel="stylesheet">
+    <link rel="preconnect" href="https://hackclub.com" crossorigin>
     <link rel="stylesheet" href="styles.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.js"></script>
 </head>
 
 <body class="noise parallax-wrapper">
-    <div class="gradient-bg">
-        <div class="gradient-blob gradient-1"></div>
-        <div class="gradient-blob gradient-2"></div>
-        <div class="gradient-blob gradient-3"></div>
-    </div>
-
-    <div class="circuit-bg"></div>
-    <div class="grid-overlay"></div>
+    <!-- Subtle gradient wash behind the hero — replaces the old gradient blobs / circuit grid -->
+    <div class="gradient-bg" aria-hidden="true"></div>
 
     <header class="site-header">
         <div class="logo-container">
@@ -156,9 +149,7 @@
             </a>
             <a href="https://github.com/hackclub/YSWS-Catalog" target="_blank" rel="noopener noreferrer"
                 class="nav-link">GitHub</a>
-            <button class="theme-toggle" id="theme-toggle">☾</button>
-            <!-- DEBUG -->
-            <!-- <button onclick="doConfettiAtCursor(event)">TEST</button> -->
+            <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">☾</button>
         </nav>
     </header>
 
@@ -213,6 +204,15 @@
                 </div>
             </div>
             <a href="#programs-list" class="cta-button">Explore Programs<span class="button-arrow">→</span></a>
+        </div>
+
+        <!-- Mountain-bump wave divider — echoes the new hackclub.com landing page -->
+        <div class="wave-divider" aria-hidden="true" style="position:absolute;bottom:-1px;left:0;right:0;">
+            <svg viewBox="0 0 1920 40" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                    d="M0,40 L0,27 C40,27 40,8 80,8 C120,8 120,27 160,27 C200,27 200,8 240,8 C280,8 280,27 320,27 C360,27 360,8 400,8 C440,8 440,27 480,27 C520,27 520,8 560,8 C600,8 600,27 640,27 C680,27 680,8 720,8 C760,8 760,27 800,27 C840,27 840,8 880,8 C920,8 920,27 960,27 C1000,27 1000,8 1040,8 C1080,8 1080,27 1120,27 C1160,27 1160,8 1200,8 C1240,8 1240,27 1280,27 C1320,27 1320,8 1360,8 C1400,8 1400,27 1440,27 C1480,27 1480,8 1520,8 C1560,8 1560,27 1600,27 C1640,27 1640,8 1680,8 C1720,8 1720,27 1760,27 C1800,27 1800,8 1840,8 C1880,8 1880,27 1920,27 L1920,40 Z"
+                    fill="var(--background)" />
+            </svg>
         </div>
     </section>
 
@@ -390,7 +390,6 @@
                 You'll receive feedback on why it wasn't approved. Depending on the reason, you may be able to make
                 adjustments and resubmit before the deadline </p>
         </details>
-        </div>
 
         <div class="faq-footer">
 
@@ -399,7 +398,6 @@
             <a href="https://hackclub.slack.com">
                 Join the Hack Club Slack →
             </a>
-        </div>
         </div>
 
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A catalog of Hack Club's You Ship, We Ship programs",
   "scripts": {
+    "dev": "npx serve",
     "generate": "node generate-json.js && node generate-rss.js",
     "validate": "node validateDates.js"
   },

--- a/script.js
+++ b/script.js
@@ -1089,6 +1089,11 @@ themeToggle.addEventListener("click", () => {
 
 
 
+// Hold the fetched stats so the count-up animation can wait until the
+// stats section actually enters the viewport.
+let globalStatsData = null;
+let globalStatsAnimated = false;
+
 async function loadGlobalStats() {
 
   try {
@@ -1097,27 +1102,12 @@ async function loadGlobalStats() {
       "https://hackclub8080.nathanyin.com/api/v1/ysws_stats"
     );
 
-    const data = await response.json();
+    globalStatsData = await response.json();
 
-    animateValue(
-      "projects-count",
-      data.total_projects
-    );
-
-    animateValue(
-      "hours-count",
-      data.total_hours
-    );
-
-    animateValue(
-      "stars-count",
-      data.total_stars
-    );
-
-    animateValue(
-      "viral-count",
-      data.viral_projects
-    );
+    // If the section is already on screen when data arrives
+    // (short page, hash anchor, etc.), animate immediately.
+    // Otherwise the IntersectionObserver triggers it on scroll-into-view.
+    maybeRunGlobalStatsAnimation();
 
   } catch (error) {
 
@@ -1127,6 +1117,51 @@ async function loadGlobalStats() {
     );
 
   }
+}
+
+function runGlobalStatsAnimation() {
+  if (globalStatsAnimated || !globalStatsData) return;
+  globalStatsAnimated = true;
+
+  animateValue("projects-count", globalStatsData.total_projects);
+  animateValue("hours-count", globalStatsData.total_hours);
+  animateValue("stars-count", globalStatsData.total_stars);
+  animateValue("viral-count", globalStatsData.viral_projects);
+}
+
+function maybeRunGlobalStatsAnimation() {
+  if (globalStatsAnimated || !globalStatsData) return;
+
+  const section = document.querySelector('.global-stats-section');
+  if (!section) return;
+
+  const rect = section.getBoundingClientRect();
+  const isOnScreen = rect.top < window.innerHeight && rect.bottom > 0;
+  if (isOnScreen) runGlobalStatsAnimation();
+}
+
+function setupGlobalStatsObserver() {
+  const section = document.querySelector('.global-stats-section');
+  if (!section) return;
+
+  // Older browsers without IntersectionObserver: just run it so the
+  // numbers still show up.
+  if (!('IntersectionObserver' in window)) {
+    runGlobalStatsAnimation();
+    return;
+  }
+
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        runGlobalStatsAnimation();
+        observer.disconnect();
+        break;
+      }
+    }
+  }, { threshold: 0.15 });
+
+  observer.observe(section);
 }
 
 function formatNumber(num) {
@@ -1171,6 +1206,7 @@ function animateValue(id, endValue) {
 
 
 window.addEventListener("DOMContentLoaded", () => {
+  setupGlobalStatsObserver();
   loadGlobalStats();
 })
 

--- a/styles.css
+++ b/styles.css
@@ -1,25 +1,91 @@
-@import url('https://fonts.googleapis.com/css2?family=Saira+Stencil:ital,wght@0,100..900;1,100..900&display=swap');
-@import url("https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap");
+/* ============================================================
+   YSWS Catalog — Redesigned to match hackclub.com (2026)
+   Visual language: editorial paper-feel, Phantom Sans + Zarathustra,
+   translucent navigation, rainbow gradient accents, wave dividers,
+   black footer, light-by-default with dark mode toggle.
+   ============================================================ */
 
-@import url("https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&display=swap");
+/* ── Fonts (Hack Club CDN with Google Fonts fallback) ─────── */
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800;900&family=Instrument+Serif:ital@0;1&display=swap');
 
-@import url("https://fonts.googleapis.com/css2?family=Syne:wght@700;800&display=swap");
+@font-face {
+  font-family: 'Phantom Sans';
+  src: url('https://hackclub.com/font/PhantomSans0.8-Book.ttf') format('truetype');
+  font-weight: 350;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Phantom Sans';
+  src: url('https://hackclub.com/font/PhantomSans0.8-Regular.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Phantom Sans';
+  src: url('https://hackclub.com/font/PhantomSans0.8-Italic.ttf') format('truetype');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Phantom Sans';
+  src: url('https://hackclub.com/font/PhantomSans0.8-Medium.ttf') format('truetype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Phantom Sans';
+  src: url('https://hackclub.com/font/PhantomSans0.8-Semibold.ttf') format('truetype');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Phantom Sans';
+  src: url('https://hackclub.com/font/PhantomSans0.8-Bold.ttf') format('truetype');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Phantom Sans';
+  src: url('https://hackclub.com/font/PhantomSans0.8-BoldItalic.ttf') format('truetype');
+  font-weight: 700;
+  font-style: italic;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Zarathustra';
+  src: url('https://hackclub.com/font/zarathustra-kerned.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
 
-@import url("https://fonts.googleapis.com/css2?family=Unbounded:wght@200..900&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Lexend:wght@100..900&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap");
-
+/* ── Tokens ─────────────────────────────────────────────── */
 :root {
-  --darker: #121217;
-  --dark: #17171d;
-  --darkless: #252429;
-  --black: #1f2d3d;
-  --steel: #273444;
-  --slate: #3c4858;
-  --muted: #8492a6;
-  --smoke: #e0e6ed;
-  --snow: #f9fafc;
-  --white: #ffffff;
+  /* Surfaces */
+  --background: #ffffff;
+  --foreground: #17171d;
+  --surface: #f9fafc;
+  --surface-hover: #f1f2f5;
+  --paper: #ffffff;
+  --cream: #fff6eb;
+  --ink: #17171d;
+  --ink-2: #2e1719;
+
+  /* Borders & dividers */
+  --border: rgba(0, 0, 0, 0.08);
+  --border-strong: rgba(0, 0, 0, 0.16);
+
+  /* Text variants */
+  --muted: rgba(23, 23, 29, 0.7);
+  --muted-2: rgba(23, 23, 29, 0.5);
+
+  /* Brand */
   --red: #ec3750;
   --orange: #ff8c37;
   --yellow: #f1c40f;
@@ -27,30 +93,40 @@
   --cyan: #5bc0de;
   --blue: #338eda;
   --purple: #a633d6;
-  --text: var(--black);
-  --background: var(--white);
-  --elevated: var(--white);
-  --sheet: var(--snow);
-  --sunken: var(--smoke);
-  --border: var(--smoke);
-  --primary: #ec3750;
-  --secondary: #8492a6;
-  --accent: #5bc0de;
-  --twitter: #1da1f2;
-  --facebook: #3b5998;
-  --instagram: #e1306c;
 
-  --faq-item-bg: rgba(70, 70, 70, 0.15);
-  --faq-item-border: rgba(255, 255, 255, 0.08);
+  /* Chrome */
+  --nav-bg: rgba(255, 255, 255, 0.82);
+  --footer-bg: #000000;
+  --footer-fg: #fff6eb;
+  --shadow-card: 0 4px 14px rgba(0, 0, 0, 0.06);
+  --shadow-card-hover: 0 16px 40px rgba(0, 0, 0, 0.12);
+  --shadow-dd: 0 8px 32px rgba(0, 0, 0, 0.13);
+  --shadow-pill: 0 6px 20px rgba(236, 55, 80, 0.28);
 
-  --theme-toggle-bg: rgba(20, 20, 20, 0.1);
+  /* Fonts */
+  --font-sans: 'Phantom Sans', 'Outfit', system-ui, -apple-system, sans-serif;
+  --font-display: 'Zarathustra', 'Instrument Serif', Georgia, serif;
+  --font-mono: 'SF Mono', 'IBM Plex Mono', 'Roboto Mono', Menlo, Consolas, monospace;
 
+  /* ── Legacy compatibility (keeps per-program brand styles working) ── */
+  --text: var(--foreground);
+  --elevated: var(--surface);
+  --sunken: var(--surface-hover);
+  --primary: var(--red);
+  --secondary: rgba(23, 23, 29, 0.55);
+  --accent: var(--cyan);
+  --white: #ffffff;
+  --black: #17171d;
+  --snow: #f9fafc;
+  --smoke: rgba(0, 0, 0, 0.08);
+  --darker: #0f0f14;
+  --dark: #17171d;
+  --darkless: #252429;
+  --steel: #273444;
+  --slate: #3c4858;
+  --sheet: #f9fafc;
 
-  --breakpoint-xs: 32em;
-  --breakpoint-s: 48em;
-  --breakpoint-m: 64em;
-  --breakpoint-l: 96em;
-  --breakpoint-xl: 128em;
+  /* Spacing/sizing (kept for compatibility) */
   --spacing-0: 0px;
   --spacing-1: 4px;
   --spacing-2: 8px;
@@ -58,1683 +134,460 @@
   --spacing-4: 32px;
   --spacing-5: 64px;
   --spacing-6: 128px;
-  --spacing-7: 256px;
-  --spacing-8: 512px;
-  --font-1: 12px;
-  --font-2: 16px;
-  --font-3: 20px;
-  --font-4: 24px;
-  --font-5: 32px;
-  --font-6: 48px;
-  --font-7: 64px;
-  --font-8: 96px;
-  --font-9: 128px;
-  --font-10: 160px;
-  --font-11: 192px;
-  --line-height-limit: 0.875;
-  --line-height-title: 1;
-  --line-height-heading: 1.125;
-  --line-height-subheading: 1.25;
-  --line-height-caption: 1.375;
-  --line-height-body: 1.5;
-  --font-weight-body: 400;
-  --font-weight-bold: 700;
-  --font-weight-heading: var(--font-weight-bold);
-  --letter-spacing-title: -0.009em;
-  --letter-spacing-headline: 0.009em;
-  --size-wide-plus: 2048px;
-  --size-wide: 1536px;
-  --size-layout-plus: 1200px;
-  --size-layout: 1024px;
-  --size-copy-ultra: 980px;
-  --size-copy-plus: 768px;
-  --size-copy: 680px;
-  --size-narrow-plus: 600px;
-  --size-narrow: 512px;
-  --radii-small: 4px;
-  --radii-default: 8px;
-  --radii-extra: 12px;
-  --radii-ultra: 16px;
+  --radii-small: 6px;
+  --radii-default: 10px;
+  --radii-extra: 14px;
+  --radii-ultra: 20px;
   --radii-circle: 99999px;
-  --shadow-text: 0 1px 2px rgba(0, 0, 0, 0.25), 0 2px 4px rgba(0, 0, 0, 0.125);
-  --shadow-small:
-    0 1px 2px rgba(0, 0, 0, 0.0625), 0 2px 4px rgba(0, 0, 0, 0.0625);
-  --shadow-card: 0 4px 8px rgba(0, 0, 0, 0.125);
-  --shadow-elevated:
-    0 1px 2px rgba(0, 0, 0, 0.0625), 0 8px 12px rgba(0, 0, 0, 0.125);
-  --dark-background: var(--darker);
-  --dark-text: var(--snow);
-  --dark-elevated: var(--dark);
-  --dark-border: var(--darkless);
-  --dark-sunken: var(--darkless);
-  --font-sans: "Outfit", system-ui, -a pple-system, sans-serif;
-  --font-family: "zarathustra", "zarathustra Fallback", Georgia, serif;
-  --gradient-1: rgba(236, 55, 80, 0.15);
-  --gradient-2: rgba(51, 142, 218, 0.15);
-  --gradient-3: rgba(51, 214, 166, 0.15);
 
-  --header-border: rgba(70, 70, 70, 0.2);
+  /* FAQ specific */
+  --faq-item-bg: rgba(23, 23, 29, 0.03);
+  --faq-item-border: rgba(0, 0, 0, 0.08);
+
+  --theme-toggle-bg: rgba(23, 23, 29, 0.04);
+  --header-border: rgba(0, 0, 0, 0.06);
+
+  color-scheme: light;
 }
 
-/* fix overscroll */
+.dark-theme {
+  --background: #17171d;
+  --foreground: #fff6eb;
+  --surface: #1f1f27;
+  --surface-hover: #2a2a33;
+  --paper: #1f1f27;
+  --cream: #fff6eb;
+  --ink: #fff6eb;
+  --ink-2: #fff6eb;
+
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.18);
+
+  --muted: rgba(255, 246, 235, 0.7);
+  --muted-2: rgba(255, 246, 235, 0.45);
+
+  --nav-bg: rgba(23, 23, 29, 0.82);
+  --footer-bg: #000000;
+  --footer-fg: #fff6eb;
+
+  --shadow-card: 0 4px 14px rgba(0, 0, 0, 0.35);
+  --shadow-card-hover: 0 16px 40px rgba(0, 0, 0, 0.5);
+  --shadow-dd: 0 8px 32px rgba(0, 0, 0, 0.6);
+
+  --text: var(--foreground);
+  --elevated: var(--surface);
+  --sunken: var(--surface-hover);
+  --secondary: rgba(255, 246, 235, 0.6);
+
+  --faq-item-bg: rgba(255, 255, 255, 0.04);
+  --faq-item-border: rgba(255, 255, 255, 0.1);
+  --theme-toggle-bg: rgba(255, 255, 255, 0.06);
+  --header-border: rgba(255, 255, 255, 0.08);
+
+  color-scheme: dark;
+}
+
+/* ── Base reset ─────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 html {
   scroll-behavior: smooth;
   overscroll-behavior-y: none;
   overflow-x: hidden;
-}
-
-.dark-theme {
-  --text: var(--dark-text);
-  --background: var(--dark-background);
-  --elevated: var(--dark-elevated);
-  --border: var(--dark-border);
-  --sunken: var(--dark-sunken);
-
-  --faq-item-bg: rgba(0, 0, 0, 0.06);
-  --faq-item-border: rgba(0, 0, 0, 0.08);
-
-  --theme-toggle-bg: rgba(70, 70, 70, 0.5);
-
-  --header-border: rgba(255, 255, 255, 0.1);
-}
-
-.theme-toggle {
-  position: relative;
-  top: auto;
-  right: auto;
-  padding: var(--spacing-2);
-  border-radius: 50%;
-  width: 40px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  cursor: pointer;
-  z-index: 10;
-  transform-origin: center;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: none;
-  font-family: var(--font-sans) !important;
-
-  color: var(--text);
-}
-
-.theme-toggle:hover {
-  transform: rotate(45deg) scale(1.1);
-  /* background: rgba(236, 55, 80, 0.1); */
+  -webkit-text-size-adjust: 100%;
 }
 
 body {
-  font-family: var(--font-family);
-  line-height: var(--line-height-body);
-  font-weight: var(--font-weight-body);
   margin: 0;
   min-height: 100vh;
-  text-rendering: optimizeLegibility;
-  font-smooth: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  color: var(--text);
-  box-sizing: border-box;
+  font-family: var(--font-sans);
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--foreground);
   background: var(--background);
-  transition:
-    background-color 0.5s ease,
-    color 0.5s ease;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-.monospace {
-  font-family: "SF Mono", "Roboto Mono", Menlo, Consolas, monospace;
-}
-
-.heading {
-  font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-heading);
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.ultratitle {
-  font-weight: 800;
-  font-size: 72px;
-  line-height: 1;
-  letter-spacing: -0.03em;
-  padding-bottom: 0.25em;
-  margin-bottom: -0.1em;
-  color: var(--red);
-  position: relative;
-}
-
-.ultratitle::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  bottom: 0;
-  transform: translateX(-50%);
-  width: 128px;
-  height: 4px;
-  background: var(--red);
-  border-radius: 999px;
-}
-
-@media screen and (max-width: 48em) {
-  .ultratitle {
-    font-size: 48px;
-  }
-}
-
-@keyframes title-gradient {
-
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-
-  50% {
-    background-position: 100% 50%;
-  }
-}
-
-@keyframes gradient-text {
-
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-
-  50% {
-    background-position: 100% 50%;
-  }
-}
-
-.title {
-  font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-title);
-  letter-spacing: var(--letter-spacing-title);
-}
-
-.subtitle {
-  margin-top: var(--spacing-3);
-  font-weight: var(--font-weight-body);
-  line-height: var(--line-height-subheading);
-  letter-spacing: var(--letter-spacing-headline);
-}
-
-.headline {
-  margin-top: var(--spacing-3);
-  margin-bottom: var(--spacing-3);
-  font-size: var(--font-4);
-  line-height: var(--line-height-heading);
-  letter-spacing: var(--letter-spacing-headline);
-}
-
-.subheadline {
-  margin-top: var(--spacing-0);
-  margin-bottom: var(--spacing-3);
-  font-size: var(--font-2);
-  line-height: var(--line-height-heading);
-  letter-spacing: var(--letter-spacing-headline);
-}
-
-.eyebrow {
-  color: var(--muted);
-  font-weight: var(--font-weight-heading);
-  letter-spacing: var(--letter-spacing-headline);
-  line-height: var(--line-height-subheading);
-  text-transform: uppercase;
-  margin-top: var(--spacing-0);
-  margin-bottom: var(--spacing-2);
-}
-
-.lead {
-  font-weight: var(--font-weight-body);
-}
-
-.caption {
-  color: var(--muted);
-  font-weight: var(--font-weight-body);
-  letter-spacing: var(--letter-spacing-headline);
-  line-height: var(--line-height-caption);
-}
-
-.pill {
-  border-radius: var(--radii-circle);
-  padding-left: var(--spacing-3);
-  padding-right: var(--spacing-3);
-  padding-top: var(--spacing-1);
-  padding-bottom: var(--spacing-1);
-  font-size: var(--font-2);
-  background: var(--primary);
-  color: var(--background);
-  font-weight: var(--font-weight-bold);
-}
-
-.outline-badge {
-  border-radius: var(--radii-circle);
-  padding-left: var(--spacing-3);
-  padding-right: var(--spacing-3);
-  padding-top: var(--spacing-1);
-  padding-bottom: var(--spacing-1);
-  font-size: var(--font-2);
-  background: none;
-  color: var(--muted);
-  border: 1px solid currentcolor;
-  font-weight: var(--font-weight-body);
-}
-
-button {
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: var(--font-weight-bold);
-  border-radius: var(--radii-circle);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: var(--shadow-card);
-  letter-spacing: var(--letter-spacing-headline);
-  -webkit-tap-highlight-color: transparent;
   transition:
-    transform 0.125s ease-in-out,
-    box-shadow 0.125s ease-in-out;
-  box-sizing: border-box;
-  margin: 0;
-  min-width: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  text-align: center;
-  line-height: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  color: var(--theme-ui-colors-white, #ffffff);
-  background-color: var(--theme-ui-colors-primary, #ec3750);
-  border: 0;
-  font-size: var(--font-2);
-}
-
-button:focus,
-button:hover {
-  box-shadow: var(--shadow-elevated);
-  transform: scale(1.0625);
-}
-
-button.lg {
-  font-size: var(--font-3) !important;
-  line-height: var(--line-height-title);
-  padding-left: var(--spacing-4);
-  padding-right: var(--spacing-4);
-  padding-top: var(--spacing-3);
-  padding-bottom: var(--spacing-3);
-}
-
-button.outline {
-  background: none;
-  color: var(--primary);
-  border: 2px solid currentcolor;
-}
-
-button.cta {
-  font-size: var(--font-2);
-  background-image: radial-gradient(ellipse farthest-corner at top left,
-      var(--orange),
-      var(--red));
-  background-size: 200% 200%;
-  background-image: linear-gradient(45deg,
-      var(--orange) 0%,
-      var(--red) 50%,
-      var(--orange) 100%);
-  animation: gradient-shift 3s ease infinite;
-}
-
-@keyframes gradient-shift {
-  0% {
-    background-position: 0% 50%;
-  }
-
-  50% {
-    background-position: 100% 50%;
-  }
-
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
-.card {
-  background: var(--elevated);
-  color: var(--text);
-  border-radius: var(--radii-extra);
-  box-shadow: var(--shadow-card);
-  overflow: hidden;
-}
-
-.card.sunken {
-  background: var(--sunken);
-  box-shadow: none;
-}
-
-.card.interactive {
-  text-decoration: none;
-  -webkit-tap-highlight-color: transparent;
-  transition:
-    transform 0.125s ease-in-out,
-    box-shadow 0.125s ease-in-out;
-}
-
-.card.interactive:hover,
-.card.interactive:focus {
-  transform: translateY(-8px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-input,
-textarea,
-select {
-  background: var(--elevated);
-  color: var(--text);
-  font-family: inherit;
-  border-radius: var(--radii-small);
-  border: 0;
-  font-size: inherit;
-  padding: var(--spacing-2);
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-input::-webkit-input-placeholder,
-input::-moz-placeholder,
-input:-ms-input-placeholder,
-textarea::-webkit-input-placeholder,
-textarea::-moz-placeholder,
-textarea:-ms-input-placeholder,
-select::-webkit-input-placeholder,
-select::-moz-placeholder,
-select:-ms-input-placeholder {
-  color: var(--muted);
-}
-
-input[type="search"]::-webkit-search-decoration,
-textarea[type="search"]::-webkit-search-decoration,
-select[type="search"]::-webkit-search-decoration {
-  display: none;
-}
-
-input[type="checkbox"] {
-  -webkit-appearance: checkbox;
-  -moz-appearance: checkbox;
-  appearance: checkbox;
-}
-
-label {
-  color: var(--text);
-  display: flex;
-  flex-direction: column;
-  text-align: left;
-  line-height: var(--line-height-caption);
-  font-size: var(--font-3);
-}
-
-label.horizontal {
-  display: flex;
-}
-
-.slider {
-  color: var(--primary);
-}
-
-.form-hidden {
-  position: absolute;
-  height: 1px;
-  width: 1px;
-  clip: rect(1px, 1px, 1px, 1px);
-  white-space: nowrap;
-}
-
-.container {
-  width: 100%;
-  margin: auto;
-  padding-left: var(--spacing-3);
-  padding-right: var(--spacing-3);
-  padding-top: var(--spacing-4);
-  max-width: 1200px;
-  margin: 2rem auto;
-  padding: 2rem;
-  box-sizing: border-box;
-}
-
-h1 {
-  font-size: var(--font-5);
-  font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-heading);
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-h2 {
-  font-size: var(--font-4);
-  font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-heading);
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-h3 {
-  font-size: var(--font-3);
-  font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-heading);
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-h4 {
-  font-size: var(--font-2);
-  font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-heading);
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-h5 {
-  font-size: var(--font-1);
-  font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-heading);
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-h6 {
-  font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-heading);
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-p {
-  color: var(--text);
-  font-weight: var(--font-weight-body);
-  line-height: var(--line-height-body);
-  margin-top: var(--spacing-3);
-  margin-bottom: var(--spacing-3);
+    background-color 0.3s ease,
+    color 0.3s ease;
 }
 
 img {
+  -webkit-user-drag: none;
+  user-select: none;
   max-width: 100%;
 }
 
-hr {
-  border: 0;
-  border-bottom: 1px solid var(--border);
-}
-
 a {
-  color: var(--primary);
-  text-decoration: underline;
-  text-underline-position: under;
+  color: var(--red);
+  text-decoration: none;
+  transition: color 0.15s ease, opacity 0.15s ease;
 }
 
-a:focus,
 a:hover {
-  text-decoration-style: wavy;
-  text-decoration-skip-ink: none;
+  color: var(--orange);
 }
 
-pre {
-  font-family: "SF Mono", "Roboto Mono", Menlo, Consolas, monospace;
-  font-size: var(--font-1);
-  padding: var(--spacing-3);
-  color: var(--text);
-  background: var(--sunken);
-  overflow: auto;
-  border-radius: var(--radii-default);
-  white-space: inherit;
-}
-
-pre>code {
-  color: inherit;
-  margin-left: 0;
-  margin-right: 0;
-  padding-left: 0;
-  padding-right: 0;
-}
-
-code {
-  font-family: "SF Mono", "Roboto Mono", Menlo, Consolas, monospace;
-  font-size: inherit;
-  color: var(--purple);
-  background: var(--sunken);
-  overflow: auto;
-  border-radius: var(--radii-small);
-  margin-left: var(--spacing-1);
-  margin-right: var(--spacing-1);
-  padding-left: var(--spacing-1);
-  padding-right: var(--spacing-1);
-}
-
-p>code,
-li>code {
-  color: var(--blue);
-  font-size: 0.875em;
-}
-
-p>a>code,
-li>a>code {
-  color: var(--blue);
-  font-size: 0.875em;
-}
-
-li {
-  margin-top: var(--spacing-2);
-  margin-bottom: var(--spacing-2);
-}
-
-table {
-  width: 100%;
-  margin-top: var(--spacing-4);
-  margin-bottom: var(--spacing-4);
-  border-collapse: separate;
-  border-spacing: 0;
-}
-
-table>th,
-table>td {
-  text-align: left;
-  padding: 4px;
-  padding-left: 0px;
-  border-color: var(--border);
-  border-bottom-style: solid;
-}
-
-th {
-  vertical-align: bottom;
-  border-bottom-width: 2px;
-}
-
-td {
-  vertical-align: top;
-  border-bottom-width: 1px;
-}
-
-.program-card {
-  margin-bottom: var(--spacing-3);
-  padding: var(--spacing-3);
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  border: 1px solid transparent;
+button {
+  font-family: inherit;
   cursor: pointer;
-  /* backdrop-filter: blur(10px); */
-  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
-.program-card:hover {
-  border-color: var(--primary);
-  transform: translateY(-8px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);
+/* Focus rings — accessible & brand-aligned */
+:focus-visible {
+  outline: 3px solid var(--red);
+  outline-offset: 3px;
+  border-radius: 4px;
 }
 
-.program-card.opens-soon {
-  border: 2px dashed var(--blue);
-  background: linear-gradient(rgba(51, 142, 218, 0.05),
-      rgba(51, 142, 218, 0.05));
-}
-
-.program-card.opens-soon .program-deadline {
-  color: var(--blue);
-  font-weight: var(--font-weight-bold);
-}
-
-.program-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--spacing-2);
-}
-
-.program-status {
-  font-size: var(--font-2) !important;
-  /* font-family: var(--font-sans); */
-  padding: var(--spacing-2) var(--spacing-3);
-  border-radius: var(--radii-circle);
-  position: relative;
-  overflow: hidden;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 70px;
-  text-align: center;
-  /* height: 24px; */
+/* ── Typography ─────────────────────────────────────────── */
+.heading,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 400;
   line-height: 1;
+  color: var(--foreground);
+  letter-spacing: -0.005em;
 }
 
-.status-active {
-  align-items: center;
-  gap: 8px;
-  color: var(--white);
-  background: #33d6a6aa;
-  /* backdrop-filter: blur(2px); */
-  animation: status-glow 2s ease-in-out infinite;
-  border: 2px solid var(--header-border);
-  min-width: 55px;
-  font-size: 11px;
+p {
+  margin: 0;
+  line-height: 1.55;
 }
 
-@keyframes status-glow {
-
-  0%,
-  100% {
-    box-shadow: 0 0 5px var(--green);
-  }
-
-  50% {
-    box-shadow: 0 0 15px var(--green);
-  }
+.monospace,
+code,
+pre {
+  font-family: var(--font-mono);
 }
 
-.status-ended {
-  background-color: var(--muted);
-  color: var(--white);
-}
-
-.status-upcoming {
-  background-color: var(--blue);
-  color: var(--white);
-}
-
-.status-draft {
-  background-color: var(--yellow);
-  color: var(--black);
-  border: 1px dashed var(--text);
-  font-weight: var(--font-weight-bold);
-  background-size: 28.28px 28.28px;
-  animation: dash-animation 1s linear infinite;
-  background-image: repeating-linear-gradient(45deg,
-      var(--yellow) 0,
-      var(--yellow) 10px,
-      var(--orange) 10px,
-      var(--orange) 20px);
-}
-
-@keyframes dash-animation {
-  from {
-    background-position: 0 0;
-  }
-
-  to {
-    background-position: 28.28px 0;
-  }
-}
-
-.program-links {
-  margin-top: var(--spacing-2);
-  display: flex;
-  gap: var(--spacing-2);
-  margin-top: auto;
-  padding-top: var(--spacing-3);
-}
-
-.category-section {
-  margin-bottom: var(--spacing-4);
-}
-
-.program-deadline {
-  font-size: var(--font-1);
-  color: var(--muted);
-  margin-top: var(--spacing-1);
-}
-
-.program-deadline.urgent {
-  color: var(--red);
-  font-weight: var(--font-weight-bold);
-}
-
-.program-deadline.very-urgent {
-  color: var(--red);
-  font-weight: var(--font-weight-bold);
-  animation: pulse 2s infinite;
-}
-
-@keyframes pulse {
-  0% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.5;
-  }
-
-  100% {
-    opacity: 1;
-  }
-}
-
-.programs-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--spacing-3);
-  margin-top: var(--spacing-3);
-  opacity: 0;
-  animation: fade-in 0.5s ease forwards;
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.filter-container {
-  display: flex;
-  gap: var(--spacing-2);
-  flex-wrap: wrap;
-  margin: var(--spacing-4) 0;
-}
-
-.filter-btn {
-  background: var(--sunken);
-  color: var(--text);
-  border: none;
-  box-shadow: none;
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
-}
-
-.filter-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  background: rgba(236, 55, 80, 0.1);
-}
-
-.filter-btn.active {
-  background: var(--primary);
-  color: var(--white);
-}
-
-.filter-btn.user-filter {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid var(--primary);
-  background: rgba(236, 55, 80, 0.1);
-  transition: all 0.3s ease;
-}
-
-.filter-btn.user-filter:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(236, 55, 80, 0.15);
-}
-
-.category-section.hidden {
-  display: none;
-}
-
-.active-count {
-  color: var(--primary);
-  font-weight: var(--font-weight-bold);
-  margin-top: var(--spacing-2);
-  margin-bottom: var(--spacing-3);
-}
-
-.search-container {
-  margin: var(--spacing-3) 0;
-  width: 100%;
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  width: 100%;
-  padding: 1.25rem 1.5rem;
-  gap: 0.5rem;
-  margin: 2rem 0;
-  font-size: 1.1rem;
-  border-radius: 50px;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
-  /* backdrop-filter: blur(10px); */
-  transition: all 0.3s ease;
-}
-
-.dark-theme .search-container {
-  background: rgba(23, 23, 29, 0.7);
-  box-shadow: 0 4px 10px rgba(255, 255, 255, 0.05);
-}
-
-.search-container:focus-within {
-  box-shadow: 0 8px 20px rgba(236, 55, 80, 0.15);
-  background: var(--elevated);
-  transform: translateY(-2px);
-}
-
-.search-container.floating {
-  position: relative;
-  max-width: 600px;
-  margin: 2rem auto;
-}
-
-.search-input {
-  width: 100%;
-  padding: 0;
-  border: none;
-  background: transparent;
-  transition: all 0.3s ease;
-}
-
-.search-input:focus {
-  outline: none;
-}
-
-.search-icon {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: var(--muted);
-}
-
-.program-card.hidden-by-search {
-  display: none;
-}
-
-.program-card.hidden-by-filter,
-.program-card.hidden-by-search {
-  display: none;
-}
-
-.modal {
-  display: none;
+/* ── Background paper texture (subtle dot grid) ─────────── */
+body::before {
+  content: '';
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.75);
-  /* backdrop-filter: blur(8px); */
-  z-index: 9999;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.modal.active {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 1;
-}
-
-.modal-content {
-  background: var(--elevated);
-  position: relative;
-  width: 90%;
-  max-width: 600px;
-  max-height: 90vh;
-  overflow-y: auto;
-  transform: translateY(-20px);
-  transition: transform 0.3s ease;
-  padding: var(--spacing-4);
-}
-
-.modal.active .modal-content {
-  transform: translateY(0);
-}
-
-.modal-close {
-  position: absolute;
-  top: var(--spacing-3);
-  right: var(--spacing-3);
-  background: none;
-  border: none;
-  font-size: var(--font-4);
-  color: var(--text);
-  padding: var(--spacing-1);
-  cursor: pointer;
-  width: 32px;
-  height: 32px;
-  box-shadow: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 10;
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--spacing-3);
-  padding-right: 40px;
-}
-
-.modal-body {
-  margin-top: var(--spacing-3);
-}
-
-.program-details {
-  margin-top: var(--spacing-4);
-}
-
-.participation-steps {
-  margin: var(--spacing-3) 0;
-}
-
-body.modal-open {
-  overflow: hidden;
-}
-
-.modal-nav {
-  position: fixed;
-  top: 50%;
-  transform: translateY(-50%);
-  background: var(--elevated);
-  border: 1px solid var(--border);
-  color: var(--text);
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  box-shadow: var(--shadow-card);
-  font-size: var(--font-4);
-  z-index: 1001;
-  opacity: 0.8;
-  font-family: var(--font-sans);
-}
-
-.modal-nav:hover {
-  background: var(--primary);
-  color: var(--white);
-  transform: translateY(-50%) scale(1.1);
-  opacity: 1;
-}
-
-
-.modal-prev {
-  left: var(--spacing-4);
-}
-
-.modal-next {
-  right: var(--spacing-4);
-}
-
-@media (max-width: 768px) {
-  .modal-nav {
-    width: 48px;
-    height: 48px;
-    font-size: var(--font-3);
-  }
-
-  .modal-prev {
-    left: var(--spacing-2);
-  }
-
-  .modal-next {
-    right: var(--spacing-2);
-  }
-
-  .link-separator {
-    display: none;
-  }
-}
-
-@media screen and (min-width: 32em) {
-  .ultratitle {
-    font-size: var(--font-5);
-  }
-
-  .title {
-    font-size: var(--font-4);
-  }
-
-  .subtitle {
-    font-size: var(--font-2);
-  }
-
-  .eyebrow {
-    font-size: var(--font-3);
-  }
-
-  .lead {
-    font-size: var(--font-2);
-    margin-top: var(--spacing-2);
-    margin-bottom: var(--spacing-2);
-  }
-
-  .card {
-    padding: var(--spacing-3);
-  }
-
-  .container {
-    max-width: var(--size-layout);
-  }
-
-  .container.copy {
-    max-width: var(--size-copy);
-  }
-
-  .container.narrow {
-    max-width: var(--size-narrow);
-  }
-
-  .programs-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media screen and (min-width: 48em) {
-  .ultratitle {
-    font-size: var(--font-6);
-  }
-
-  .title {
-    font-size: var(--font-5);
-  }
-
-  .subtitle {
-    font-size: var(--font-3);
-  }
-
-  .eyebrow {
-    font-size: var(--font-4);
-  }
-
-  .lead {
-    font-size: var(--font-3);
-    margin-top: var(--spacing-3);
-    margin-bottom: var(--spacing-3);
-  }
-
-  .card {
-    padding: var(--spacing-4);
-  }
-
-  .programs-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media screen and (min-width: 64em) {
-  .ultratitle {
-    font-size: var(--font-7);
-  }
-
-  .title {
-    font-size: var(--font-6);
-  }
-
-  .container {
-    max-width: var(--size-layout-plus);
-  }
-
-  .container.wide {
-    max-width: var(--size-wide);
-  }
-
-  .container.copy {
-    max-width: var(--size-copy-plus);
-  }
-
-  .container.narrow {
-    max-width: var(--size-narrow-plus);
-  }
-
-  .programs-grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
-}
-
-.program-position {
-  position: fixed;
-  top: var(--spacing-3);
-  left: 50%;
-  transform: translateX(-50%);
-  color: var(--white);
-  font-size: var(--font-2);
-  font-weight: var(--font-weight-bold);
-  letter-spacing: var(--letter-spacing-headline);
-  background: var(--slate);
-  padding: var(--spacing-2) var(--spacing-3);
-  border-radius: var(--radii-circle);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  z-index: 1002;
-}
-
-.modal.active .program-position {
-  opacity: 0.9;
-}
-
-.program-position:hover {
-  opacity: 1;
-}
-
-.sort-container {
-  display: flex;
-  gap: var(--spacing-2);
-  flex-wrap: wrap;
-  margin-bottom: var(--spacing-4);
-}
-
-.sort-btn {
-  background: var(--elevated);
-  color: var(--text);
-  border: 1px solid var(--border);
-  box-shadow: none;
-  transition: all 0.3s ease;
-  font-size: var(--font-1);
-  padding: var(--spacing-1) var(--spacing-2);
-}
-
-.sort-btn.active {
-  background: var(--primary);
-  color: var(--white);
-  border-color: var(--primary);
-}
-
-.sort-btn:hover {
-  transform: none;
-  box-shadow: none;
-  background: var(--smoke);
-}
-
-@media screen and (max-width: 48em) {
-
-  .filter-container,
-  .sort-container {
-    justify-content: center;
-    margin: var(--spacing-2) 0;
-  }
-}
-
-.program-participants {
-  font-size: var(--font-1);
-  color: var(--muted);
-  margin-top: var(--spacing-2);
-  font-weight: var(--font-weight-bold);
-  transition: opacity 0.3s ease;
-}
-
-.program-participants span {
-  display: inline-block;
-  transition: transform 0.3s ease;
-}
-
-.program-participants.updating {
-  opacity: 0.5;
-}
-
-.program-participants {
-  font-size: var(--font-1);
-  color: var(--muted);
-  margin-top: var(--spacing-2);
-  font-weight: var(--font-weight-bold);
-  transition: opacity 0.3s ease;
-}
-
-.program-participants.updating {
-  opacity: 0.5;
-}
-
-.program-participants {
-  font-size: var(--font-1);
-  color: var(--muted);
-  margin-top: var (--spacing-2);
-  font-weight: var(--font-weight-bold);
-}
-
-.noise {
-  position: relative;
-  overflow-x: hidden;
-  width: 100%;
-}
-
-.noise::before {
-  content: "";
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3C/rect%3E%3C/svg%3E");
-  opacity: 0.02;
+  inset: 0;
   pointer-events: none;
-  z-index: -1;
+  z-index: 0;
+  background-image: radial-gradient(circle, rgba(23, 23, 29, 0.05) 1px, transparent 1px);
+  background-size: 28px 28px;
+  background-position: 0 0;
+  opacity: 0.55;
 }
 
+.dark-theme body::before,
+body.dark-theme::before {
+  background-image: radial-gradient(circle, rgba(255, 246, 235, 0.07) 1px, transparent 1px);
+}
+
+/* Decorative gradient wash behind hero */
 .gradient-bg {
   position: fixed;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  transform: translateZ(0);
-  z-index: -2;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba(236, 55, 80, 0.04) 0%,
+    rgba(255, 140, 55, 0.03) 30%,
+    rgba(255, 255, 255, 0) 70%
+  );
 }
 
-.gradient-1,
-.gradient-2,
-.gradient-3 {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(80px);
-  opacity: 0.5;
-  /* animation: gradient-shift 8s ease infinite alternate; */
+.gradient-blob,
+.circuit-bg,
+.grid-overlay {
+  display: none !important;
 }
 
-.gradient-1 {
-  /* background: radial-gradient(circle, rgba(236, 55, 80, 0.4) 0%, rgba(236, 55, 80, 0) 70%); */
-  width: 600px;
-  height: 600px;
-  left: -100px;
-  top: -100px;
+.dark-theme .gradient-bg {
+  background: linear-gradient(
+    180deg,
+    rgba(236, 55, 80, 0.08) 0%,
+    rgba(255, 140, 55, 0.04) 30%,
+    rgba(0, 0, 0, 0) 70%
+  );
 }
 
-.gradient-2 {
-  background: var(--gradient-2);
-  width: 700px;
-  height: 700px;
-  right: -100px;
-  top: 50%;
-  animation-delay: -2s;
+body.noise {
+  /* Soft paper noise via inline base64 — keeps the editorial feel */
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.04 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  background-size: 160px 160px;
 }
 
-.gradient-3 {
-  background: var(--gradient-3);
-  width: 500px;
-  height: 500px;
-  left: 50%;
-  bottom: -100px;
-  animation-delay: -4s;
+/* ── Layout containers ──────────────────────────────────── */
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+  position: relative;
+  z-index: 1;
 }
 
-@keyframes gradient-shift {
-  0% {
-    transform: translate(0, 0) scale(1);
-  }
-
-  100% {
-    transform: translate(50px, 50px) scale(1.1);
-  }
+main,
+section,
+header,
+footer {
+  position: relative;
+  z-index: 1;
 }
 
+/* The catalog uses .glassmorphic on the programs wrapper — we
+   re-interpret it as a clean paper sheet rather than a glass surface. */
 .glassmorphic {
-  background: rgba(255, 255, 255, 0.8);
-  /* backdrop-filter: blur(20px); */
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 24px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: none;
 }
 
 .dark-theme .glassmorphic {
-  background: rgba(23, 23, 29, 0.8);
+  background: var(--surface);
+  border-color: var(--border);
 }
 
-.header-content {
-  text-align: center;
-  margin-bottom: 4rem;
-}
-
+/* ── Site header (translucent, blurred, sticky) ─────────── */
 .site-header {
-  /* position: fixed; */
+  position: sticky;
   top: 0;
-  left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
   z-index: 100;
-  background: rgba(255, 255, 255, 0.5);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 28px;
+  background: var(--nav-bg);
+  backdrop-filter: saturate(180%) blur(18px);
+  -webkit-backdrop-filter: saturate(180%) blur(18px);
   border-bottom: 1px solid var(--header-border);
-  transition: all 0.3s ease;
-  box-sizing: border-box;
-  /* should be fine to blur header if it's not sticky */
-  backdrop-filter: blur(8px);
-}
-
-.dark-theme .site-header {
-  background: rgba(18, 18, 23, 0.5);
-}
-
-.site-header.scrolled {
-  padding: 0.75rem 2rem;
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-}
-
-.dark-theme .site-header.scrolled {
-  background: rgba(18, 18, 23, 0.8);
 }
 
 .logo-container {
   display: flex;
   align-items: center;
-  position: relative;
-  z-index: 101;
+}
+
+.logo-container a {
+  display: inline-flex;
+  align-items: center;
+  transition: transform 0.2s ease;
+}
+
+.logo-container a:hover {
+  transform: scale(1.04);
 }
 
 .logo {
-  height: 80px;
+  height: 38px;
   width: auto;
-  transition: transform 0.3s ease;
-  margin-top: -20px;
-  margin-bottom: -20px;
-}
-
-.logo:hover {
-  transform: scale(1.05);
+  display: block;
 }
 
 .main-nav {
   display: flex;
-  gap: 1.5rem;
   align-items: center;
+  gap: 6px;
 }
 
 .nav-link {
-  color: var(--text);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 14px;
+  border-radius: 9999px;
+  font-family: var(--font-sans);
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--foreground);
   text-decoration: none;
-  font-weight: 600;
-  padding: 0.5rem 0.75rem;
-  border-radius: var(--radii-default);
-  position: relative;
-  transition: all 0.3s ease;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
 }
 
-.nav-link:after {
-  content: "";
-  position: absolute;
-  width: 0%;
-  height: 2px;
-  bottom: 0;
-  left: 0;
-  background: var(--primary);
-  transition: width 0.3s ease;
+.nav-link:hover {
+  background: var(--surface-hover);
+  color: var(--foreground);
 }
 
-.nav-link:hover:after {
-  width: 100%;
+.nav-link.rss-link svg {
+  color: var(--orange);
 }
 
 .theme-toggle {
   position: relative;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  display: flex;
+  width: 38px;
+  height: 38px;
+  margin-left: 6px;
+  padding: 0;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  background: var(--theme-toggle-bg);
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 16px;
   cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  box-shadow: none;
+  transition:
+    transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .theme-toggle:hover {
-  transform: rotate(45deg) scale(1.1);
-  background: rgba(236, 55, 80, 0.1);
+  transform: rotate(30deg) scale(1.06);
+  background: var(--surface-hover);
 }
 
-/* .gradient-bg {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -10;
-  overflow: hidden;
-  background: rgba(18, 18, 23, 0.5);
-} */
-
-.gradient-bg {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -10;
-  overflow: hidden;
-
-  background-image:
-    radial-gradient(circle at 0% 0%, var(--gradient-1) 0%, transparent 45%),
-    radial-gradient(circle at 100% 30%, var(--gradient-2) 0%, transparent 55%),
-    radial-gradient(circle at 30% 100%, var(--gradient-3) 0%, transparent 50%);
-}
-
-/* .gradient-blob {
-  position: absolute;
-  border-radius: 50%;
-  opacity: 0.5;
-}
-
-.gradient-1 {
-  background: var(--gradient-1);
-  width: 600px;
-  height: 600px;
-  left: -100px;
-  top: -100px;
-}
-
-.gradient-2 {
-  background: var(--gradient-2);
-  width: 800px;
-  height: 800px;
-  right: -200px;
-  top: 30%;
-}
-
-.gradient-3 {
-  background: var(--gradient-3);
-  width: 700px;
-  height: 700px;
-  left: 30%;
-  bottom: -200px;
-} */
-
-/* @keyframes float-animation {
-  0% {
-    transform: translate(0, 0) scale(1);
-  }
-
-  50% {
-    transform: translate(-50px, 50px) scale(1.1);
-  }
-
-  100% {
-    transform: translate(50px, -20px) scale(0.95);
-  }
-} */
-
-.circuit-bg {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-image: url("data:image/svg+xml,%3Csvg width='100' height='100' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M20 10 H80 V20 H20 V10z M80 10v10 M20 20v40 M80 20v40 M20 60h25 M45 60v10 M45 70h35 M20 30h25 M45 30h35 M45 30v10 M80 40v20 M50 40h10 M60 40v10' fill='none' stroke-width='1' stroke-opacity='0.03' stroke='%23ec3750'/%3E%3C/svg%3E");
-  opacity: 0.4;
-  z-index: -5;
-  pointer-events: none;
-}
-
-.grid-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-image:
-    linear-gradient(to right, rgba(0, 0, 0, 0.03) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
-  background-size: 50px 50px;
-  z-index: -6;
-  pointer-events: none;
-}
-
-.dark-theme .grid-overlay {
-  background-image:
-    linear-gradient(to right, rgba(255, 255, 255, 0.02) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
-}
-
+/* ── Hero ───────────────────────────────────────────────── */
 .hero-section {
-  min-height: 100vh;
+  position: relative;
+  padding: 80px 24px 120px;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-top: 80px;
-  position: relative;
+  min-height: 78vh;
+  background: linear-gradient(
+    180deg,
+    rgba(236, 55, 80, 0.03) 0%,
+    rgba(236, 55, 80, 0.12) 100%
+  );
+  overflow: hidden;
+}
+
+.dark-theme .hero-section {
+  background: linear-gradient(
+    180deg,
+    rgba(236, 55, 80, 0.06) 0%,
+    rgba(236, 55, 80, 0.18) 100%
+  );
 }
 
 .hero-content {
-  max-width: 1000px;
+  position: relative;
+  z-index: 2;
+  max-width: 980px;
   margin: 0 auto;
   text-align: center;
-  position: relative;
-  padding: 2rem;
-  box-sizing: border-box;
-  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
+/* Tiny editorial eyebrow above the headline */
 .hero-animated-text {
-  display: block;
-  font-size: 3rem;
-  font-weight: 800;
-  margin-bottom: 1rem;
-  line-height: 1.2;
-  letter-spacing: -0.02em;
-  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 22px;
+  padding: 8px 16px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: var(--nav-bg);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  backdrop-filter: blur(10px);
 }
 
 .hero-animated-text .hero-text-shadow {
-  display: block;
-  color: var(--text);
+  color: var(--muted);
 }
 
 .hero-animated-text .animated-element {
-  display: block;
-  color: var(--primary);
   position: relative;
-  padding: 0.5rem 0;
-  animation: focus-in 1s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+  color: var(--red);
+  font-weight: 700;
 }
 
-@keyframes focus-in {
-  0% {
-    /* filter: blur(12px); */
-    transform: scale(1.2);
-  }
-
-  100% {
-    /* filter: blur(0); */
-    transform: scale(1);
-  }
+.hero-animated-text .animated-element::before {
+  content: '✦';
+  margin-right: 6px;
+  color: var(--orange);
 }
 
+/* The hero headline mirrors the new site's editorial serif. */
 .hero-title {
-  font-size: 6rem;
-  font-weight: 900;
-  margin: 1rem 0 1.5rem;
-  letter-spacing: -0.03em;
-  line-height: 1.2;
-  padding-bottom: 0.5rem;
-  color: var(--text);
-  position: relative;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-  transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-  cursor: default;
-}
-
-.hero-title:hover {
-  transform: translateY(-8px);
-  text-shadow: 0 8px 16px rgba(236, 55, 80, 0.3);
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: clamp(48px, 9vw, 96px);
+  line-height: 0.95;
   letter-spacing: -0.01em;
-}
-
-.hero-title .accent {
-  background: linear-gradient(90deg, var(--red) 0%, var(--orange) 100%);
-  background-clip: text;
-  -webkit-background-clip: text;
-  color: transparent;
-  position: relative;
-  display: inline-block;
+  margin: 0 0 18px;
+  color: var(--foreground);
 }
 
 .hero-title::after {
-  content: "";
-  position: absolute;
-  bottom: -0.75rem;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 100px;
-  height: 5px;
-  background: linear-gradient(90deg, var(--red), var(--orange), var(--red));
-  background-size: 200% auto;
-  background-position: 0% center;
-  border-radius: 10px;
-  transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+  display: none;
 }
 
-.hero-title:hover::after {
-  width: 180px;
-  height: 6px;
-  box-shadow: 0 3px 10px rgba(236, 55, 80, 0.5);
-  background-position: 100% center;
-  animation: shine 2s linear infinite;
+@keyframes ysws-gradient {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
 }
 
-@keyframes shine {
-  from {
-    background-position: 0% center;
-  }
-
-  to {
-    background-position: 200% center;
-  }
+.hero-title .accent {
+  background: repeating-linear-gradient(
+    105deg,
+    #ec3750 0%,
+    #ff8c37 16%,
+    #f1c40f 32%,
+    #33d6a6 48%,
+    #338eda 64%,
+    #a633d6 80%,
+    #ec3750 100%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation: ysws-gradient 7s linear infinite;
 }
 
 .hero-description {
-  font-size: 1.5rem;
-  max-width: 800px;
-  margin: 0 auto 2.5rem;
-  color: var(--text);
-  opacity: 0.9;
-  line-height: 1.6;
+  font-family: var(--font-sans);
+  font-size: clamp(17px, 1.4vw, 21px);
+  font-weight: 400;
+  line-height: 1.45;
+  color: var(--foreground);
+  max-width: 600px;
+  margin: 0 0 36px;
+  text-align: center;
 }
 
+/* Hero cards — kept paper-light, clean borders, flip retained */
 .hero-cards {
-  display: flex;
-  gap: 2rem;
-  justify-content: center;
-  margin-bottom: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  width: 100%;
+  max-width: 620px;
+  margin: 8px auto 36px;
   perspective: 1000px;
 }
 
 .hero-card {
-  width: 280px;
-  height: 200px;
-  position: relative;
-  transform-style: preserve-3d;
-  transform: perspective(1000px);
+  height: 180px;
+  perspective: 1000px;
 }
 
 .hero-card-inner {
@@ -1742,7 +595,7 @@ body.modal-open {
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
-  transition: transform 0.8s;
+  transition: transform 0.55s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .hero-card:hover .hero-card-inner {
@@ -1752,1348 +605,1542 @@ body.modal-open {
 .hero-card-front,
 .hero-card-back {
   position: absolute;
-  width: 100%;
-  height: 100%;
-  backface-visibility: hidden;
+  inset: 0;
+  border-radius: 20px;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-  padding: 2rem;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-}
-
-.hero-card-front {
-  background: rgba(255, 255, 255, 0.5);
-  /* backdrop-filter: blur(15px); */
-}
-
-.hero-card-back {
-  transform: rotateY(180deg);
-  padding: 1.5rem;
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: none;
+  justify-content: center;
+  text-align: center;
+  padding: 22px 18px;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
 }
 
 .dark-theme .hero-card-front,
 .dark-theme .hero-card-back {
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--surface);
+  border-color: var(--border);
 }
 
-.dark-theme .hero-card-front {
-  background: rgba(23, 23, 29, 0.6);
-  /* backdrop-filter: blur(15px); */
+.hero-card-front {
+  gap: 10px;
 }
 
-.dark-theme .hero-card-back {
-  background: rgba(23, 23, 29, 0.95);
-  backdrop-filter: none;
+.hero-card-back {
+  transform: rotateY(180deg);
+  background: var(--ink);
+  color: var(--cream);
+  border-color: var(--ink);
 }
 
 .hero-card-icon {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--red);
+  background: rgba(236, 55, 80, 0.08);
+  border-radius: 12px;
+}
+
+.hero-card-icon .icon {
+  width: 26px;
+  height: 26px;
 }
 
 .hero-card h3 {
-  font-size: 1.25rem;
-  font-weight: 700;
-  margin: 0 0 0.5rem;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 22px;
+  margin: 0;
+  color: var(--foreground);
 }
 
-.hero-card p {
+.hero-card-front p {
   margin: 0;
-  font-size: 1rem;
-  color: var(--text);
-  opacity: 0.8;
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.4;
 }
 
 .hero-card-back p {
-  line-height: 1.6;
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.4;
+  color: var(--cream);
 }
 
+/* CTA pill button — black with arrow that slides on hover */
 .cta-button {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  background: var(--primary);
-  color: white;
-  font-size: 1.2rem;
-  font-weight: 700;
-  padding: 1rem 2.5rem;
-  border-radius: 50px;
+  gap: 10px;
+  padding: 14px 24px;
+  background: var(--ink);
+  color: var(--cream);
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 16px;
+  border-radius: 9999px;
+  border: 1px solid var(--ink);
   text-decoration: none;
-  position: relative;
-  overflow: hidden;
-  transition: all 0.3s ease;
-  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.2);
-  transform: translateY(0);
-  scroll-behavior: smooth;
+  transition:
+    background-color 0.35s ease,
+    color 0.35s ease,
+    transform 0.2s ease,
+    box-shadow 0.3s ease;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
 }
 
 .cta-button:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 8px 0 rgba(0, 0, 0, 0.2);
-  text-decoration: none;
+  background: var(--red);
+  border-color: var(--red);
+  color: #fff;
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-pill);
 }
 
-.cta-button:active {
-  transform: translateY(0);
-  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.2);
-}
-
-.button-arrow {
+.cta-button .button-arrow {
   display: inline-block;
-  transition: transform 0.3s ease;
+  transition: transform 0.25s ease;
 }
 
 .cta-button:hover .button-arrow {
-  transform: translateX(5px);
+  transform: translateX(6px);
 }
 
-.programs-container {
+/* ── Wave divider (between hero and stats etc.) ─────────── */
+.wave-divider {
   position: relative;
-  margin-top: 5rem;
-  margin-bottom: 5rem;
-  padding: 3rem;
-  border-radius: 24px;
-  border: 1px solid var(--header-border);
-  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.1);
-  background: rgba(255, 255, 255, 0.9);
-  /* backdrop-filter: blur(15px); */
-  scroll-margin-top: 100px;
-  box-sizing: border-box;
   width: 100%;
+  height: 40px;
+  margin-top: -1px;
+  line-height: 0;
+  pointer-events: none;
+}
+
+.wave-divider svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ── Global stats section ───────────────────────────────── */
+.global-stats-section {
+  padding: 96px 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+}
+
+.impact-heading {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: clamp(60px, 10vw, 120px);
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+  margin: 0 0 56px;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.2em;
+  flex-wrap: wrap;
+}
+
+.impact-solid {
+  color: var(--foreground);
+}
+
+.impact-outline {
+  color: transparent;
+  -webkit-text-stroke: 2px var(--foreground);
+  font-style: italic;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+.stat-card {
+  padding: 36px 20px;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  box-shadow: var(--shadow-card);
+  transition:
+    transform 0.25s ease,
+    box-shadow 0.25s ease,
+    border-color 0.25s ease;
+}
+
+.dark-theme .stat-card {
+  background: var(--surface);
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-card-hover);
+  border-color: var(--red);
+}
+
+.stat-card .stat-number {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: clamp(40px, 6vw, 64px);
+  line-height: 1;
+  color: var(--foreground);
+  margin-bottom: 8px;
+  letter-spacing: -0.02em;
+}
+
+.stat-card .stat-label {
+  font-family: var(--font-sans);
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.stats-footer {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 18px;
+  background: var(--nav-bg);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  backdrop-filter: blur(10px);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 0 rgba(51, 214, 166, 0.7);
+  animation: live-pulse 2s infinite;
+}
+
+@keyframes live-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(51, 214, 166, 0.7); }
+  70% { box-shadow: 0 0 0 8px rgba(51, 214, 166, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(51, 214, 166, 0); }
+}
+
+.live-data-attribute {
+  color: var(--muted);
+}
+
+.stats-source {
+  color: var(--red);
+  font-weight: 600;
+}
+
+.stats-source:hover {
+  color: var(--orange);
+}
+
+/* ── Programs container (paper sheet) ──────────────────── */
+.programs-container {
+  max-width: 1280px;
+  margin: 24px auto 80px;
+  padding: 44px clamp(20px, 4vw, 56px);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  box-shadow: var(--shadow-card);
+  position: relative;
+  z-index: 1;
 }
 
 .dark-theme .programs-container {
-  background: rgba(18, 18, 23, 0.8);
+  background: var(--surface);
 }
 
 .programs-header {
   display: flex;
+  align-items: flex-end;
   justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 2rem;
+  gap: 24px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
 }
 
 .programs-title-container {
-  flex: 1;
+  flex: 1 1 320px;
 }
 
 .section-title {
-  font-size: 3rem;
-  font-weight: 800;
-  margin: 0;
-  position: relative;
-  line-height: 1.2;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: clamp(40px, 6vw, 64px);
+  line-height: 0.95;
+  letter-spacing: -0.015em;
+  color: var(--foreground);
+  margin: 0 0 8px;
 }
 
 .section-title .accent {
-  color: var(--primary);
+  background: repeating-linear-gradient(
+    105deg,
+    #ec3750 0%,
+    #ff8c37 16%,
+    #f1c40f 32%,
+    #33d6a6 48%,
+    #338eda 64%,
+    #a633d6 80%,
+    #ec3750 100%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation: ysws-gradient 7s linear infinite;
 }
 
-.programs-subtitle {
-  max-width: 600px;
-  margin-top: 0.5rem;
-}
-
-.lead {
-  font-size: 1.25rem;
-  color: var(--text);
-  opacity: 0.9;
-  line-height: 1.6;
+.programs-subtitle .lead {
+  font-family: var(--font-sans);
+  font-size: 17px;
+  color: var(--muted);
   margin: 0;
+  max-width: 540px;
 }
 
 .programs-stats {
   display: flex;
-  align-items: center;
-  gap: 2rem;
+  gap: 16px;
 }
 
-.stat {
+.programs-stats .stat {
+  padding: 18px 22px;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 18px;
   text-align: center;
-  min-width: 120px;
+  min-width: 130px;
 }
 
-.stat-number {
-  font-size: 2.5rem;
-  font-weight: 800;
-  color: var(--primary);
+.dark-theme .programs-stats .stat {
+  background: var(--surface-hover);
+}
+
+.programs-stats .stat-number {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 32px;
   line-height: 1;
+  color: var(--foreground);
 }
 
-.stat-label {
-  font-size: 1rem;
-  color: var (--text);
-  opacity: 0.8;
-  margin-top: 0.25rem;
-}
-
-.controls-wrapper {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin: 2rem 0;
-}
-
-.filter-container,
-.sort-container {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.filter-btn,
-.sort-btn {
-  padding: 0.75rem 1.25rem;
-  border-radius: 50px;
-  font-size: 0.95rem;
-  font-weight: 600;
-  background: rgba(255, 255, 255, 0.8);
-  color: var (--text);
-  border: none;
-  transition: all 0.3s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-.dark-theme .filter-btn,
-.dark-theme .sort-btn {
-  background: rgba(23, 23, 29, 0.7);
-}
-
-.filter-btn:hover,
-.sort-btn:hover {
-  background: rgba(236, 55, 80, 0.1);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(236, 55, 80, 0.15);
-}
-
-.filter-btn.active,
-.sort-btn.active {
-  background: var(--primary);
-  color: white;
-}
-
-.programs-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1.5rem;
-  margin-top: 2rem;
-}
-
-.program-card {
-  position: relative;
-  border: 1px solid var(--header-border);
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.8);
-  /* backdrop-filter: blur(10px); */
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 1.5rem;
-  height: 100%;
-  transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  display: flex;
-  flex-direction: column;
-  cursor: pointer;
-  overflow: hidden;
-}
-
-.dark-theme .program-card {
-  background: rgba(23, 23, 29, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.program-card::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(135deg,
-      rgba(255, 255, 255, 0) 0%,
-      rgba(255, 255, 255, 0.1) 100%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  z-index: 1;
-  pointer-events: none;
-}
-
-.program-card:hover {
-  transform: translateY(-8px) scale(1.02);
-  box-shadow: 0 20px 30px rgba(0, 0, 0, 0.1);
-  border-color: var(--primary);
-}
-
-.program-card:hover::before {
-  opacity: 1;
-}
-
-.site-footer {
-  position: relative;
-  padding: 3rem 0 2rem;
-  margin-top: 5rem;
-  background: var(--elevated);
-  overflow: hidden;
-}
-
-.footer-content {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1rem;
-  box-sizing: border-box;
-  width: 100%;
-}
-
-.footer-column {
-  flex: 1;
-  min-width: 200px;
-}
-
-.footer-logo {
-  display: inline-block;
-  margin-bottom: 1rem;
-}
-
-html {
-  scroll-behavior: smooth;
-}
-
-.rss-link {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.rss-link svg {
-  color: var(--primary);
-  transition: transform 0.3s ease;
-}
-
-.rss-link:hover svg {
-  transform: scale(1.2);
-}
-
-.program-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: var(--spacing-3);
-}
-
-.program-completion-toggle {
-  border: none;
-  background: rgba(255, 255, 255, 0.2);
-  color: var(--text);
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: none;
-  padding: 0;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  margin-left: var(--spacing-2);
-  /* backdrop-filter: blur(5px); */
-  border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.dark-theme .program-completion-toggle {
-  background: rgba(23, 23, 29, 0.5);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.program-completion-toggle:hover {
-  transform: scale(1.1);
-  background: rgba(51, 214, 166, 0.2);
-  box-shadow: 0 0 10px rgba(51, 214, 166, 0.3);
-}
-
-.program-completion-toggle.completed {
-  background: var(--green);
-  color: white;
-}
-
-.program-completion-toggle.completed:hover {
-  background: var(--red);
-}
-
-.user-completed-badge {
-
-  /* REDUNDENT DESIGN */
-  display: none !important;
-
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: var(--font-1);
-  font-weight: var(--font-weight-bold);
-  color: var(--white);
-  background: linear-gradient(135deg, var(--green) 0%, #25a080 100%);
-  border: none;
-  padding: var(--spacing-2) var(--spacing-2) !important;
-  border-radius: var(--radii-circle);
-  margin-right: var(--spacing-2);
-  opacity: 0;
-  transform: translateY(10px);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  pointer-events: none;
-  visibility: hidden;
-  box-shadow: 0 2px 8px rgba(51, 214, 166, 0.3);
-  position: relative;
-  overflow: hidden;
-  z-index: 2;
-}
-
-.user-completed-badge::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg,
-      rgba(255, 255, 255, 0) 0%,
-      rgba(255, 255, 255, 0.2) 50%,
-      rgba(255, 255, 255, 0) 100%);
-  transform: translateX(-100%);
-  animation: shimmer 2s infinite;
-  z-index: -1;
-}
-
-@keyframes shimmer {
-  100% {
-    transform: translateX(100%);
-  }
-}
-
-.user-completed-badge.visible {
-  opacity: 1;
-  transform: translateY(0);
-  visibility: visible;
-}
-
-.user-completed-badge svg {
-  filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.5));
-}
-
-.status-container {
-  display: flex;
-  align-items: center;
-  flex-wrap: nowrap;
-}
-
-.modal-completion-toggle {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: var(--font-2);
-  font-weight: var(--font-weight-bold);
-  background: rgba(255, 255, 255, 0.1);
-  color: var(--text);
-  padding: var(--spacing-2) var(--spacing-3);
-  border-radius: var(--radii-circle);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  margin-top: var(--spacing-3);
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  /* backdrop-filter: blur(5px); */
-}
-
-.dark-theme .modal-completion-toggle {
-  background: rgba(23, 23, 29, 0.5);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.modal-completion-toggle:hover {
-  transform: translateY(-2px);
-  background: rgba(51, 214, 166, 0.2);
-  box-shadow: 0 4px 12px rgba(51, 214, 166, 0.2);
-}
-
-.modal-completion-toggle.completed {
-  background: var(--green);
-  color: white;
-}
-
-.modal-completion-toggle.completed:hover {
-  background: var(--red);
-  box-shadow: 0 4px 12px #ec374f90;
-}
-
-.modal-completion-badge {
-  display: none;
-  align-items: center;
-  gap: 8px;
-  font-size: var(--font-2);
-  font-weight: var(--font-weight-bold);
-  color: var(--green);
-  background: rgba(51, 214, 166, 0.1);
-  border: 1px solid var(--green);
-  padding: var(--spacing-2) var(--spacing-3);
-  border-radius: var(--radii-circle);
-  margin-bottom: var(--spacing-3);
-  opacity: 0;
-  transform: translateY(10px);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  pointer-events: none;
-
-  display: none !important;
-}
-
-.modal-completion-badge.visible {
-  display: inline-flex;
-  opacity: 1;
-  transform: translateY(0);
-  visibility: visible;
-}
-
-.modal-completion-container {
-  display: flex;
-  flex-direction: column;
-  margin-top: var(--spacing-3);
-}
-
-@media (max-width: 768px) {
-  .status-container {
-    flex-direction: column;
-    align-items: flex-end;
-  }
-
-  .user-completed-badge {
-    margin-bottom: var(--spacing-1);
-    margin-right: 0;
-  }
-}
-
-.no-results-message {
-  display: none;
-  text-align: center;
-  padding: var(--spacing-5);
-  font-size: var(--font-3);
+.programs-stats .stat-label {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
   color: var(--muted);
-  width: 100%;
-  border: 2px dashed var(--border);
-  border-radius: var(--radii-default);
-  margin: var(--spacing-4) 0;
-  background: rgba(255, 255, 255, 0.05);
-  /* backdrop-filter: blur(5px); */
+  margin-top: 4px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.no-results-message.visible {
-  display: block;
-  animation: fade-in 0.5s ease forwards;
-}
-
-.no-results-message h3 {
-  font-size: var(--font-4);
-  margin-bottom: var(--spacing-2);
-  color: var(--text);
-}
-
-.no-results-message p {
-  margin-bottom: var(--spacing-3);
-}
-
-.no-results-message .action-hint {
-  font-weight: var(--font-weight-bold);
-  color: var(--primary);
-}
-
-.no-results-icon {
-  font-size: 3rem;
-  margin-bottom: var(--spacing-3);
-  opacity: 0.7;
-}
-
-@media (max-width: 768px) {
-  .site-header {
-    padding: 0.75rem 1rem;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .logo {
-    height: 60px;
-    margin-top: -15px;
-    margin-bottom: -15px;
-  }
-
-  .main-nav {
-    gap: 0.75rem;
-    flex-wrap: wrap;
-    justify-content: center;
-    width: 100%;
-    order: 3;
-    margin-top: 0.5rem;
-  }
-
-  .nav-link {
-    font-size: 0.9rem;
-    padding: 0.4rem 0.6rem;
-  }
-
-  .theme-toggle {
-    width: 36px;
-    height: 36px;
-    font-size: 1rem;
-  }
-
-  .hero-section {
-    min-height: 90vh;
-    padding-top: 120px;
-    padding-bottom: 2rem;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .hero-content {
-    padding: 1rem;
-    max-width: 100%;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .hero-animated-text {
-    font-size: 2rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .hero-title {
-    font-size: 3rem;
-    margin: 0.5rem 0 1rem;
-    line-height: 1.1;
-  }
-
-  .hero-title::after {
-    width: 60px;
-    height: 3px;
-    bottom: -0.5rem;
-  }
-
-  .hero-title:hover::after {
-    width: 100px;
-    height: 4px;
-  }
-
-  .hero-description {
-    font-size: 1.1rem;
-    margin: 0 auto 2rem;
-    padding: 0 1rem;
-  }
-
-  .hero-cards {
-    flex-direction: column;
-    gap: 1rem;
-    margin-bottom: 2rem;
-    align-items: center;
-    width: 100%;
-  }
-
-  .hero-card {
-    width: 100%;
-    max-width: 320px;
-    height: 180px;
-  }
-
-  .hero-card-front,
-  .hero-card-back {
-    padding: 1.5rem;
-  }
-
-  .hero-card-icon {
-    font-size: 2rem;
-    margin-bottom: 0.75rem;
-  }
-
-  .hero-card h3 {
-    font-size: 1.1rem;
-    color: var(--text);
-  }
-
-  .hero-card p {
-    font-size: 0.9rem;
-  }
-
-  .cta-button {
-    font-size: 1rem;
-    padding: 0.875rem 2rem;
-    width: 100%;
-    max-width: 280px;
-    justify-content: center;
-  }
-
-  .programs-container {
-    margin-top: 3rem;
-    margin-bottom: 3rem;
-    padding: 1.5rem;
-    border-radius: 16px;
-    width: auto !important;
-    box-sizing: border-box;
-  }
-
-  .programs-header {
-    flex-direction: column;
-    gap: 1rem;
-    align-items: center;
-    text-align: center;
-  }
-
-  .section-title {
-    font-size: 2rem;
-    line-height: 1.2;
-  }
-
-  .programs-subtitle {
-    max-width: 100%;
-  }
-
-  .lead {
-    font-size: 1rem;
-  }
-
-  .programs-stats {
-    gap: 1rem;
-  }
-
-  .stat {
-    min-width: 100px;
-  }
-
-  .stat-number {
-    font-size: 2rem;
-  }
-
-  .stat-label {
-    font-size: 0.9rem;
-  }
-
-  .search-container {
-    margin: 1.5rem 0;
-    padding: 1rem 1.25rem;
-    font-size: 1rem;
-  }
-
-  .controls-wrapper {
-    flex-direction: column;
-    gap: 1rem;
-    margin: 1.5rem 0;
-    width: 100%;
-  }
-
-  .filter-container,
-  .sort-container {
-    justify-content: center;
-    gap: 0.5rem;
-    width: 100%;
-    flex-wrap: wrap;
-  }
-
-  .filter-btn,
-  .sort-btn {
-    padding: 0.6rem 1rem;
-    font-size: 0.85rem;
-    border-radius: 25px;
-  }
-
-  .programs-grid {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-    margin-top: 1.5rem;
-    width: 100%;
-  }
-
-  .program-card {
-    padding: 1.25rem;
-    border-radius: 12px;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .program-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-
-  .program-status {
-    align-self: flex-start;
-    /* font-size: 0.75rem; */
-    min-width: 60px;
-    /* height: 20px; */
-  }
-
-  .status-active {
-    min-width: 50px;
-    font-size: 10px;
-  }
-
-  .modal-content {
-    width: 95%;
-    max-width: none;
-    margin: 1rem;
-    padding: 1.5rem;
-    border-radius: 16px;
-    box-sizing: border-box;
-  }
-
-  .modal-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-    padding-right: 0;
-  }
-
-  .modal-close {
-    top: 1rem;
-    right: 1rem;
-    width: 28px;
-    height: 28px;
-    font-size: 1.25rem;
-  }
-
-  .site-footer {
-    padding: 2rem 0 1.5rem;
-    margin-top: 3rem;
-    width: 100%;
-  }
-
-  .footer-content {
-    flex-direction: column;
-    text-align: center;
-    gap: 1.5rem;
-    padding: 0 1rem;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .footer-column {
-    min-width: auto;
-  }
-
-  .container {
-    padding: 1rem;
-    margin: 1rem auto;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .status-container {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-
-  .user-completed-badge {
-    margin-bottom: 0.5rem;
-    margin-right: 0;
-    font-size: 0.75rem;
-    padding: 0.25rem 0.5rem;
-  }
-
-  /* .modal-nav:hover {
-    background: var(--primary);
-    color: var(--white);
-    transform: translateY(-50%) scale(1.1);
-    opacity: 1;
-  } */
-
-  .modal-nav {
-    width: 40px;
-    height: 40px;
-    font-size: 1.25rem;
-  }
-
-  .modal-prev {
-    left: 0.5rem;
-  }
-
-  .modal-next {
-    right: 0.5rem;
-  }
-
-  .program-links {
-    /* flex-direction: column; */
-    justify-content: space-around;
-    gap: var(--spacing-4);
-    width: 100%;
-  }
-
-  .program-links a {
-    /* width: 1%; */
-    text-align: center;
-    padding: 0.5rem 1rem 0.5rem 1rem;
-    box-sizing: border-box;
-    border-radius: var(--radii-circle);
-    background-color: var(--primary);
-    color: var(--text);
-    transition: ease-in-out 0.3s all;
-    text-decoration: none;
-  }
-
-  .modal-nav {
-    top: 90%;
-    width: 120px;
-    font-size: 30px !important;
-    height: 50px;
-    border-radius: var(--radii-circle);
-  }
-
-  .program-links a:active {
-    translate: 0px -3px;
-  }
-
-  .gradient-1 {
-    width: 400px;
-    height: 400px;
-    left: -50px;
-    top: -50px;
-  }
-
-  .gradient-2 {
-    width: 500px;
-    height: 500px;
-    right: -100px;
-  }
-
-  .gradient-3 {
-    width: 350px;
-    height: 350px;
-    left: 20%;
-    bottom: -100px;
-  }
-
-  .circuit-bg {
-    opacity: 0.2;
-  }
-
-  .grid-overlay {
-    background-size: 30px 30px;
-  }
-}
-
-@media (max-width: 480px) {
-  .hero-animated-text {
-    font-size: 1.75rem;
-  }
-
-  .hero-title {
-    font-size: 2.5rem;
-  }
-
-  .hero-description {
-    font-size: 1rem;
-    padding: 0 0.5rem;
-  }
-
-  .hero-card {
-    height: 160px;
-  }
-
-  .hero-card-front,
-  .hero-card-back {
-    padding: 1.25rem;
-  }
-
-  .hero-card-icon {
-    font-size: 1.75rem;
-  }
-
-  .hero-card h3 {
-    font-size: 1rem;
-  }
-
-  .hero-card p {
-    font-size: 0.85rem;
-  }
-
-  .section-title {
-    font-size: 1.75rem;
-  }
-
-  .programs-container {
-    padding: 1rem;
-    margin: 1rem;
-  }
-
-  .search-container {
-    padding: 0.875rem 1rem;
-    font-size: 0.95rem;
-  }
-
-  .filter-btn,
-  .sort-btn {
-    padding: 0.5rem 0.875rem;
-    font-size: 0.8rem;
-  }
-
-  .program-card {
-    padding: 1rem;
-  }
-
-  .modal-content {
-    margin: 0.5rem;
-    padding: 1.25rem;
-  }
-
-  .site-header {
-    padding: 0.5rem;
-  }
-
-  .logo {
-    height: 50px;
-    margin-top: -10px;
-    margin-bottom: -10px;
-  }
-
-  .main-nav {
-    gap: 0.5rem;
-  }
-
-  .nav-link {
-    font-size: 0.85rem;
-    padding: 0.3rem 0.5rem;
-  }
-}
-
-@media (max-width: 768px) and (orientation: landscape) {
-  .hero-section {
-    min-height: 80vh;
-    padding-top: 100px;
-  }
-
-  .hero-cards {
-    flex-direction: row;
-    gap: 1rem;
-  }
-
-  .hero-card {
-    width: 45%;
-    max-width: 200px;
-    height: 150px;
-  }
-
-  .hero-card-front,
-  .hero-card-back {
-    padding: 1rem;
-  }
-
-  .hero-card-icon {
-    font-size: 1.5rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .hero-card h3 {
-    font-size: 0.9rem;
-  }
-
-  .hero-card p {
-    font-size: 0.75rem;
-  }
-}
-
-@media (hover: none) and (pointer: coarse) {
-  .hero-card:hover .hero-card-inner {
-    transform: none;
-  }
-
-  .program-card:hover {
-    transform: none;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  }
-
-  .cta-button:hover {
-    transform: none;
-    box-shadow: 0 4px 0 rgba(0, 0, 0, 0.2);
-  }
-
-  .filter-btn:hover,
-  .sort-btn:hover {
-    transform: none;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  }
-
-  .nav-link:hover:after {
-    width: 0%;
-  }
-
-  .theme-toggle:hover {
-    transform: none;
-  }
-}
-
-@media (-webkit-min-device-pixel-ratio: 2),
-(min-resolution: 192dpi) {
-  .hero-title {
-    text-shadow: 0 1px 5px rgba(0, 0, 0, 0.05);
-  }
-
-  .hero-title:hover {
-    text-shadow: 0 4px 8px rgba(236, 55, 80, 0.3);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .hero-animated-text .animated-element {
-    animation: none;
-  }
-
-  .hero-title::after {
-    animation: none;
-  }
-
-  .hero-card-inner {
-    transition: none;
-  }
-
-  .program-card {
-    transition: none;
-  }
-
-  .cta-button {
-    transition: none;
-  }
-
-  .filter-btn,
-  .sort-btn {
-    transition: none;
-  }
-
-  .nav-link:after {
-    transition: none;
-  }
-
-  .theme-toggle {
-    transition: none;
-  }
-
-  .gradient-1,
-  .gradient-2,
-  .gradient-3 {
-    animation: none;
-  }
-}
-
-#timeline-container {
-  display: flex;
-  flex-direction: column;
-  color: black;
-  margin-left: -3rem;
-  margin-right: -3rem;
-  background-color: var(--background);
-  overflow-x: auto;
-  overflow-y: hidden;
+/* ── Timeline ──────────────────────────────────────────── */
+.timeline {
   position: relative;
-  max-height: 25rem;
-
-  transition:
-    background-color 0.5s ease,
-    color 0.5s ease;
-
-  border-bottom: 1px solid var(--header-border);
+  margin: 22px 0 6px;
+  padding: 14px 18px;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  overflow: hidden;
+  max-height: 130px;
+  transition: max-height 0.4s ease;
 }
 
-#timeline-container::-webkit-scrollbar {
-  height: 12px;
+.dark-theme .timeline {
+  background: var(--surface-hover);
 }
 
-#timeline-container::-webkit-scrollbar-track {
-  background: var(--sunken);
-}
-
-#timeline-container::-webkit-scrollbar-thumb {
-  background-color: var(--primary);
-  border-radius: var(--radii-default);
-  border: 3px solid var(--sunken);
-}
-
-#timeline-container::-webkit-scrollbar-thumb:hover {
-  background-color: #b22b3b;
-}
-
-.dark-theme #timeline-container::-webkit-scrollbar {
-  height: 12px;
-}
-
-.dark-theme #timeline-container::-webkit-scrollbar-track {
-  background: var(--darkless);
-}
-
-.dark-theme #timeline-container::-webkit-scrollbar-thumb {
-  background-color: var(--primary);
-  border-radius: var(--radii-default);
-  border: 3px solid var(--darkless);
-}
-
-.dark-theme #timeline-container::-webkit-scrollbar-thumb:hover {
-  background-color: #b22b3b;
-}
-
-@media (max-width: 768px) and (orientation: portrait) {
-  #timeline-container {
-    margin: -1rem -1rem;
-  }
-}
-
-.timeline-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin: 0.5rem 10rem 0 0;
-  transform-origin: left;
-
-  transition:
-    translate 0.25s ease,
-    box-shadow 0.25s ease,
-    transform 0.25s ease;
-}
-
-.timeline-block {
-  position: relative;
-  height: 2rem;
-  padding-left: 0.5rem;
-  border-radius: 0 0.4rem 0.4rem 0;
-  background: red;
-  flex-shrink: 0;
-  overflow: visible;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  transform-origin: left center;
-  transition: transform 0.25s ease;
-  transition: opacity 0.25s;
-  transition: 0.2s;
-  /* transition: filter 0.5s; */
-}
-
-.timeline-row:hover,
-.timeline-row:focus {
-  box-shadow: var(--text);
-  cursor: pointer;
-}
-
-.timeline-row:hover .timeline-block,
-.timeline-row:focus .timeline-block {
-  opacity: 0.7;
-  /* filter: brightness(1.5); */
-  /* filter: hue-rotate(180deg); */
-  /* transform: scaleY(1.3); */
-  /* transform: scaleY(1.3); */
-}
-
-.timeline-label {
-  position: sticky;
-  left: 0;
-  z-index: 1;
-  display: inline-block;
-  white-space: nowrap;
-  pointer-events: none;
-  text-align: center;
-  padding-left: 10px;
-  padding-right: 10px;
+.timeline.expanded {
+  max-height: 600px;
 }
 
 #date-container {
-  position: sticky;
-  top: 0;
-  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+#month-container,
+#day-container {
+  display: flex;
+  position: relative;
 }
 
 #day-container {
-  display: flex;
-}
-
-.timeline-day {
-  width: 1rem;
-  height: 1.5rem;
-  border-left: 2px solid var(--border);
-  flex-shrink: 0;
-}
-
-#month-container {
-  display: flex;
-  position: relative;
-  height: 2rem;
-  font-weight: bold;
+  height: 1rem;
 }
 
 .timeline-month {
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  padding: 0.5rem;
+  padding: 0.4rem;
   border-left: 2px solid var(--border);
-  color: var(--text);
+  color: var(--foreground);
   white-space: nowrap;
-  left: 0;
   z-index: 3;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 12px;
 }
 
 .month-label {
   position: sticky;
-  left: 1rem;
-
+  left: 0.5rem;
   padding-right: 0.5rem;
   z-index: 5;
 }
 
-.timeline-label.inside {
-  white-space: nowrap;
+.timeline-day {
+  flex-shrink: 0;
+  width: 1rem;
+  border-left: 1px solid var(--border);
+}
+
+#timeline {
+  position: relative;
+  margin-top: 8px;
+  min-height: 60px;
+}
+
+#timeline-overlay {
+  position: absolute;
   pointer-events: none;
-  font-weight: bold;
-  color: var(--black);
+  inset: auto 0 0 0;
+  height: 28px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0), var(--paper));
+}
+
+.dark-theme #timeline-overlay {
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0), var(--surface-hover));
+}
+
+.timeline.expanded #timeline-overlay {
+  opacity: 0;
+}
+
+.timeline-label.inside,
+.timeline-label.outside {
+  white-space: nowrap;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 11px;
+}
+
+.timeline-label.inside {
+  color: #ffffff;
 }
 
 .timeline-label.outside {
-  white-space: nowrap;
-  color: var(--text);
-}
-
-/* So programs with no deadline fill width up to longest block with deadline, not just container */
-/* .no-deadline-timeline {
-  flex: 1;
-} */
-
-#timeline-overlay {
-  z-index: 10;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 4rem;
-  pointer-events: none;
-  min-height: 10rem;
-
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0), var(--background));
+  color: var(--foreground);
 }
 
 #timeline-expand-btn-container {
   display: flex;
   justify-content: center;
-  align-items: center;
+  margin: 4px 0 16px;
 }
 
 #timeline-expand-btn {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  background: var(--paper);
+  color: var(--foreground);
   cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
-.hidden {
+#timeline-expand-btn:hover {
+  background: var(--surface-hover);
+  border-color: var(--red);
+  transform: translateY(2px);
+}
+
+#timeline-expand-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
+/* ── Search ─────────────────────────────────────────────── */
+.search-container {
+  position: relative;
+  margin: 18px 0 24px;
+  max-width: 100%;
+}
+
+.search-icon {
+  position: absolute;
+  left: 18px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.search-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.search-input {
+  width: 100%;
+  padding: 14px 18px 14px 50px;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  outline: none;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.dark-theme .search-input {
+  background: var(--surface-hover);
+}
+
+.search-input::placeholder {
+  color: var(--muted-2);
+}
+
+.search-input:focus {
+  border-color: var(--red);
+  box-shadow: 0 0 0 4px rgba(236, 55, 80, 0.15);
+}
+
+/* ── Filter / sort buttons ──────────────────────────────── */
+.controls-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 28px;
+}
+
+.filter-container,
+.sort-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.filter-btn,
+.sort-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 16px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--foreground);
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.dark-theme .filter-btn,
+.dark-theme .sort-btn {
+  background: var(--surface-hover);
+}
+
+.filter-btn:hover,
+.sort-btn:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+
+.dark-theme .filter-btn:hover,
+.dark-theme .sort-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.filter-btn.active,
+.sort-btn.active {
+  background: var(--ink);
+  color: var(--cream);
+  border-color: var(--ink);
+}
+
+.dark-theme .filter-btn.active,
+.dark-theme .sort-btn.active {
+  background: var(--cream);
+  color: var(--ink);
+  border-color: var(--cream);
+}
+
+.filter-btn.user-filter {
+  color: var(--purple);
+  border-color: rgba(166, 51, 214, 0.3);
+}
+
+.filter-btn.user-filter:hover {
+  background: rgba(166, 51, 214, 0.08);
+}
+
+.filter-btn.user-filter.active {
+  background: var(--purple);
+  border-color: var(--purple);
+  color: #fff;
+}
+
+/* ── Program cards ──────────────────────────────────────── */
+#programs-container {
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+#programs-container > section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+#programs-container > section > h2 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 28px;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+  margin: 0 0 4px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+#programs-container > section > h2::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+#programs-container > section > div {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 18px;
+}
+
+.card,
+.program-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 22px 22px 18px;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  box-shadow: var(--shadow-card);
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.25s ease,
+    border-color 0.25s ease;
+}
+
+.dark-theme .card,
+.dark-theme .program-card {
+  background: var(--surface);
+  border-color: var(--border);
+}
+
+.program-card::before {
+  content: none; /* drop the old gradient overlay — paper feel instead */
+}
+
+.program-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-card-hover);
+  border-color: rgba(236, 55, 80, 0.4);
+}
+
+.program-card:hover::before {
+  opacity: 0;
+}
+
+.program-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.program-header h3 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 24px;
+  line-height: 1.05;
+  color: var(--foreground);
+  margin: 0;
+  letter-spacing: -0.005em;
+}
+
+.program-card > p {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.status-container {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.program-status {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-radius: 9999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--muted);
+}
+
+.status-active,
+.program-status.status-active {
+  background: rgba(51, 214, 166, 0.12);
+  color: #1f9a78;
+  border-color: rgba(51, 214, 166, 0.3);
+}
+
+.status-ended,
+.program-status.status-ended {
+  background: rgba(132, 146, 166, 0.12);
+  color: var(--muted);
+  border-color: var(--border);
+}
+
+.status-draft,
+.program-status.status-draft {
+  background: rgba(255, 140, 55, 0.12);
+  color: #d27227;
+  border-color: rgba(255, 140, 55, 0.3);
+}
+
+.status-ending-soon,
+.program-status.status-ending-soon {
+  background: rgba(236, 55, 80, 0.12);
+  color: var(--red);
+  border-color: rgba(236, 55, 80, 0.3);
+}
+
+.dark-theme .status-active,
+.dark-theme .program-status.status-active {
+  color: #5fe7b8;
+}
+
+.dark-theme .status-draft,
+.dark-theme .program-status.status-draft {
+  color: var(--orange);
+}
+
+.dark-theme .status-ending-soon,
+.dark-theme .program-status.status-ending-soon {
+  color: #ff6b86;
+}
+
+.user-completed-badge {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 9999px;
+  background: var(--green);
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.user-completed-badge.visible {
+  display: inline-flex;
+}
+
+.user-completed-badge svg {
+  width: 14px;
+  height: 14px;
+}
+
+.program-deadline {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+
+.program-deadline.ending-soon {
+  color: var(--red);
+}
+
+.program-deadline.draft {
+  color: var(--orange);
+}
+
+.completion-count {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.program-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: auto;
+  padding-top: 10px;
+}
+
+.program-links {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+
+.program-links a {
+  color: var(--red);
+  font-weight: 600;
+}
+
+.program-links a:hover {
+  color: var(--orange);
+}
+
+.link-separator {
+  color: var(--muted-2);
+}
+
+.program-completion-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 9999px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.program-completion-toggle:hover {
+  background: rgba(51, 214, 166, 0.12);
+  border-color: var(--green);
+  color: var(--green);
+  transform: scale(1.08);
+}
+
+.program-completion-toggle.completed {
+  background: var(--green);
+  border-color: var(--green);
+  color: #fff;
+}
+
+.program-completion-toggle.completed:hover {
+  background: #29b88e;
+  border-color: #29b88e;
+  transform: scale(1.08);
+}
+
+.program-card.hidden-by-filter,
+.program-card.hidden-by-search {
+  display: none !important;
+}
+
+.no-results-message {
+  display: none;
+  padding: 48px 24px;
+  text-align: center;
+  background: var(--paper);
+  border: 1px dashed var(--border);
+  border-radius: 20px;
+  color: var(--muted);
+}
+
+.dark-theme .no-results-message {
+  background: var(--surface-hover);
+}
+
+.no-results-message.visible {
+  display: block;
+}
+
+.no-results-message h3 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 26px;
+  color: var(--foreground);
+  margin: 0 0 8px;
+}
+
+.no-results-message p {
+  margin: 0 0 18px;
+  color: var(--muted);
+}
+
+.no-results-message .filter-btn {
+  margin: 0 auto;
+}
+
+.no-results-icon {
+  font-size: 40px;
+  margin-bottom: 8px;
+}
+
+.fade-in {
+  animation: ysws-fade-in 0.4s ease both;
+}
+
+@keyframes ysws-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Modal ──────────────────────────────────────────────── */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(23, 23, 29, 0.55);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.modal.active {
+  display: flex;
+  opacity: 1;
+}
+
+.modal-content {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.25);
+  padding: 36px 36px 28px;
+  transform: translateY(20px) scale(0.98);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.dark-theme .modal-content {
+  background: var(--surface);
+}
+
+.modal.active .modal-content {
+  transform: translateY(0) scale(1);
+}
+
+.modal-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 38px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  color: var(--foreground);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.dark-theme .modal-close {
+  background: var(--surface-hover);
+}
+
+.modal-close:hover {
+  background: var(--red);
+  border-color: var(--red);
+  color: #fff;
+  transform: rotate(90deg);
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding-right: 56px;
+  margin-bottom: 16px;
+}
+
+.modal-header .title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: clamp(28px, 4vw, 40px);
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+  margin: 0;
+}
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.modal-body .program-description {
+  font-family: var(--font-sans);
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--foreground);
+  margin: 0;
+}
+
+.modal-body .program-deadline {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.modal-body .program-details h3 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 22px;
+  margin: 12px 0 10px;
+  color: var(--foreground);
+}
+
+.participation-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0 0 14px;
+  padding: 0;
+}
+
+.participation-steps ol,
+.participation-steps ul {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--foreground);
+}
+
+.participation-steps li {
+  margin-bottom: 6px;
+  line-height: 1.5;
+}
+
+.more-details {
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.modal-body .program-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.modal-body .program-links a {
+  color: var(--red);
+}
+
+.modal-body .program-links a:hover {
+  color: var(--orange);
+}
+
+.modal-completion-container {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 8px;
+}
+
+.modal-completion-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--foreground);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.dark-theme .modal-completion-toggle {
+  background: var(--surface-hover);
+}
+
+.modal-completion-toggle:hover {
+  background: rgba(51, 214, 166, 0.12);
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.modal-completion-toggle.completed {
+  background: var(--green);
+  border-color: var(--green);
+  color: #fff;
+}
+
+.modal-completion-toggle.completed:hover {
+  background: #29b88e;
+  border-color: #29b88e;
+  color: #fff;
+}
+
+.modal-completion-badge {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 6px 12px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--green);
+  background: rgba(51, 214, 166, 0.1);
+  border: 1px solid rgba(51, 214, 166, 0.3);
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.modal-completion-badge.visible {
+  display: inline-flex;
+}
+
+.modal-completion-badge svg {
+  width: 14px;
+  height: 14px;
+}
+
+.modal-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  color: var(--foreground);
+  font-size: 20px;
+  cursor: pointer;
+  z-index: 2;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.dark-theme .modal-nav {
+  background: var(--surface);
+}
+
+.modal-nav:hover {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--cream);
+  transform: translateY(-50%) scale(1.06);
+}
+
+.modal-prev {
+  left: max(16px, calc(50vw - 420px));
+}
+
+.modal-next {
+  right: max(16px, calc(50vw - 420px));
+}
+
+@media (max-width: 800px) {
+  .modal-prev { left: 8px; }
+  .modal-next { right: 8px; }
+}
+
+.program-position {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--muted);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.modal.active .program-position {
+  opacity: 1;
+}
+
+/* ── FAQ section ────────────────────────────────────────── */
+.faq-section {
+  max-width: 880px;
+  margin: 80px auto;
+  padding: 56px 24px;
+  position: relative;
+  z-index: 1;
+}
+
+.faq-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: clamp(40px, 6vw, 64px);
+  line-height: 0.95;
+  letter-spacing: -0.015em;
+  color: var(--foreground);
+  text-align: center;
+  margin: 0 0 36px;
+}
+
+.faq-subtitle {
+  color: var(--muted);
+  text-align: center;
+  margin: -22px 0 36px;
+}
+
+.faq-item {
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 18px 22px;
+  margin-bottom: 14px;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.dark-theme .faq-item {
+  background: var(--surface);
+}
+
+.faq-item:hover {
+  border-color: var(--border-strong);
+}
+
+.faq-item[open] {
+  border-color: var(--red);
+  background: var(--paper);
+}
+
+.dark-theme .faq-item[open] {
+  background: var(--surface);
+}
+
+.faq-item summary {
+  list-style: none;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 17px;
+  color: var(--foreground);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.faq-item summary::-webkit-details-marker {
   display: none;
 }
 
+.faq-item summary::after {
+  content: '+';
+  font-family: var(--font-display);
+  font-size: 28px;
+  line-height: 0.8;
+  color: var(--muted);
+  transition: transform 0.25s ease, color 0.25s ease;
+}
+
+.faq-item[open] summary::after {
+  transform: rotate(45deg);
+  color: var(--red);
+}
+
+.faq-item p {
+  margin: 14px 0 0;
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.faq-footer {
+  margin-top: 36px;
+  padding: 24px;
+  text-align: center;
+  font-family: var(--font-sans);
+  color: var(--muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+}
+
+.faq-footer a {
+  margin-left: 6px;
+  color: var(--red);
+  font-weight: 600;
+}
+
+.faq-footer a:hover {
+  color: var(--orange);
+}
+
+/* ── Footer (black, cream type — matches new site) ──────── */
+.site-footer,
+footer {
+  margin-top: 80px;
+  padding: 56px 24px 40px;
+  background: var(--footer-bg);
+  color: var(--footer-fg);
+  border-radius: 0;
+  border: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+  position: relative;
+  z-index: 1;
+}
+
+.site-footer::before {
+  content: '';
+  position: absolute;
+  inset: -40px 0 auto 0;
+  height: 40px;
+  background: var(--footer-bg);
+  -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1920 40' preserveAspectRatio='none'><path d='M0,40 L0,27 C40,27 40,8 80,8 C120,8 120,27 160,27 C200,27 200,8 240,8 C280,8 280,27 320,27 C360,27 360,8 400,8 C440,8 440,27 480,27 C520,27 520,8 560,8 C600,8 600,27 640,27 C680,27 680,8 720,8 C760,8 760,27 800,27 C840,27 840,8 880,8 C920,8 920,27 960,27 C1000,27 1000,8 1040,8 C1080,8 1080,27 1120,27 C1160,27 1160,8 1200,8 C1240,8 1240,27 1280,27 C1320,27 1320,8 1360,8 C1400,8 1400,27 1440,27 C1480,27 1480,8 1520,8 C1560,8 1560,27 1600,27 C1640,27 1640,8 1680,8 C1720,8 1720,27 1760,27 C1800,27 1800,8 1840,8 C1880,8 1880,27 1920,27 L1920,40 Z' /></svg>");
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1920 40' preserveAspectRatio='none'><path d='M0,40 L0,27 C40,27 40,8 80,8 C120,8 120,27 160,27 C200,27 200,8 240,8 C280,8 280,27 320,27 C360,27 360,8 400,8 C440,8 440,27 480,27 C520,27 520,8 560,8 C600,8 600,27 640,27 C680,27 680,8 720,8 C760,8 760,27 800,27 C840,27 840,8 880,8 C920,8 920,27 960,27 C1000,27 1000,8 1040,8 C1080,8 1080,27 1120,27 C1160,27 1160,8 1200,8 C1240,8 1240,27 1280,27 C1320,27 1320,8 1360,8 C1400,8 1400,27 1440,27 C1480,27 1480,8 1520,8 C1560,8 1560,27 1600,27 C1640,27 1640,8 1680,8 C1720,8 1720,27 1760,27 C1800,27 1800,8 1840,8 C1880,8 1880,27 1920,27 L1920,40 Z' /></svg>");
+  -webkit-mask-size: 100% 100%;
+  mask-size: 100% 100%;
+  pointer-events: none;
+}
+
+.footer-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+
+.footer-column {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  color: var(--footer-fg);
+  flex: 1 1 220px;
+}
+
+.footer-logo {
+  display: inline-flex;
+}
+
+.footer-logo img {
+  width: 40px;
+  height: 40px;
+  filter: brightness(1) saturate(1.1);
+}
+
+.footer-column p {
+  font-family: var(--font-sans);
+  font-size: 15px;
+  color: var(--footer-fg);
+  margin: 0;
+}
+
+.footer-column .caption {
+  font-size: 13px;
+  color: rgba(255, 246, 235, 0.7);
+}
+
+.footer-column a {
+  color: var(--orange);
+  font-weight: 600;
+}
+
+.footer-column a:hover {
+  color: #ffb672;
+}
+
+/* ── Utilities ──────────────────────────────────────────── */
+.parallax-wrapper {
+  /* legacy hook — kept as no-op so existing markup still validates */
+}
+
+.hidden,
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    padding: 12px 16px;
+  }
+
+  .main-nav {
+    gap: 4px;
+  }
+
+  .nav-link {
+    padding: 8px 10px;
+    font-size: 14px;
+  }
+
+  .programs-container {
+    padding: 28px 18px;
+    border-radius: 22px;
+  }
+
+  .modal-content {
+    padding: 28px 22px 20px;
+  }
+
+  .modal-header {
+    padding-right: 44px;
+  }
+
+  .programs-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .programs-stats {
+    width: 100%;
+  }
+
+  .programs-stats .stat {
+    flex: 1;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-section {
+    padding: 56px 16px 80px;
+  }
+
+  .hero-card {
+    height: 160px;
+  }
+}
+
+/* Reduce motion for users who prefer it */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ============================================================
+   PER-PROGRAM BRAND STYLES (preserved from prior design)
+   These hand-crafted treatments give each program its own
+   on-card visual identity (background art, themed colors,
+   stickers, etc.). They sit on top of the new base styles.
+   ============================================================ */
 /* Blueprint-specific card styling */
 .program-card.blueprint-card {
   --color-bp-lighter: #344b6a;
@@ -5671,4 +4718,3 @@ footer {
 /* .user-completed-badge.visible {
   height: auto !important;
   padding: auto !important;
-} */

--- a/styles.css
+++ b/styles.css
@@ -789,6 +789,12 @@ footer {
   border: 1px solid var(--border);
   border-radius: 22px;
   box-shadow: var(--shadow-card);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   transition:
     transform 0.25s ease,
     box-shadow 0.25s ease,
@@ -811,7 +817,6 @@ footer {
   font-size: clamp(40px, 6vw, 64px);
   line-height: 1;
   color: var(--foreground);
-  margin-bottom: 8px;
   letter-spacing: -0.02em;
 }
 
@@ -821,6 +826,7 @@ footer {
   font-weight: 500;
   color: var(--muted);
   letter-spacing: 0.02em;
+  text-align: center;
 }
 
 .stats-footer {

--- a/styles.css
+++ b/styles.css
@@ -1057,20 +1057,84 @@ footer {
   opacity: 0;
 }
 
+/* Per-program rows on the timeline — one bar per program, with breathing
+   room between them so the bars don't run together. */
+.timeline-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 10rem 8px 0;
+  cursor: pointer;
+  transform-origin: left;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.timeline-row:first-child {
+  margin-top: 2px;
+}
+
+.timeline-row:last-child {
+  margin-bottom: 4px;
+}
+
+.timeline-row:hover,
+.timeline-row:focus {
+  transform: translateX(2px);
+}
+
+.timeline-block {
+  position: relative;
+  height: 26px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  background: var(--red);
+  border-radius: 0 999px 999px 0;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.timeline-row:hover .timeline-block,
+.timeline-row:focus .timeline-block {
+  opacity: 0.85;
+}
+
+.timeline-block.no-deadline-timeline {
+  box-shadow: none;
+}
+
+.timeline-label {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  padding: 0 4px;
+}
+
 .timeline-label.inside,
 .timeline-label.outside {
   white-space: nowrap;
   font-family: var(--font-sans);
   font-weight: 600;
   font-size: 11px;
+  letter-spacing: 0.01em;
 }
 
 .timeline-label.inside {
   color: #ffffff;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
 .timeline-label.outside {
   color: var(--foreground);
+}
+
+.timeline-label.hidden {
+  display: none;
 }
 
 #timeline-expand-btn-container {

--- a/styles.css
+++ b/styles.css
@@ -103,6 +103,11 @@
   --shadow-dd: 0 8px 32px rgba(0, 0, 0, 0.13);
   --shadow-pill: 0 6px 20px rgba(236, 55, 80, 0.28);
 
+  /* Inverted pill (CTA + active filter) — flips between light & dark themes
+     so the pill always pops against its parent surface. */
+  --invert-bg: #17171d;
+  --invert-fg: #fff6eb;
+
   /* Fonts */
   --font-sans: 'Phantom Sans', 'Outfit', system-ui, -apple-system, sans-serif;
   --font-display: 'Zarathustra', 'Instrument Serif', Georgia, serif;
@@ -157,8 +162,14 @@
   --surface-hover: #2a2a33;
   --paper: #1f1f27;
   --cream: #fff6eb;
-  --ink: #fff6eb;
-  --ink-2: #fff6eb;
+  /* Keep --ink as the brand dark — it must NOT flip with the theme,
+     otherwise pills using ink/cream resolve to the same color. */
+  --ink: #17171d;
+  --ink-2: #2e1719;
+
+  /* Inverted pill flips in dark mode so the pill is the LIGHT colour. */
+  --invert-bg: #fff6eb;
+  --invert-fg: #17171d;
 
   --border: rgba(255, 255, 255, 0.08);
   --border-strong: rgba(255, 255, 255, 0.18);
@@ -632,9 +643,9 @@ footer {
 
 .hero-card-back {
   transform: rotateY(180deg);
-  background: var(--ink);
-  color: var(--cream);
-  border-color: var(--ink);
+  background: var(--invert-bg);
+  color: var(--invert-fg);
+  border-color: var(--invert-bg);
 }
 
 .hero-card-icon {
@@ -673,22 +684,22 @@ footer {
   font-family: var(--font-sans);
   font-size: 15px;
   line-height: 1.4;
-  color: var(--cream);
+  color: var(--invert-fg);
 }
 
-/* CTA pill button — black with arrow that slides on hover */
+/* CTA pill button — inverts with the theme so it always pops */
 .cta-button {
   display: inline-flex;
   align-items: center;
   gap: 10px;
   padding: 14px 24px;
-  background: var(--ink);
-  color: var(--cream);
+  background: var(--invert-bg);
+  color: var(--invert-fg);
   font-family: var(--font-sans);
   font-weight: 600;
   font-size: 16px;
   border-radius: 9999px;
-  border: 1px solid var(--ink);
+  border: 1px solid var(--invert-bg);
   text-decoration: none;
   transition:
     background-color 0.35s ease,
@@ -1203,16 +1214,9 @@ footer {
 
 .filter-btn.active,
 .sort-btn.active {
-  background: var(--ink);
-  color: var(--cream);
-  border-color: var(--ink);
-}
-
-.dark-theme .filter-btn.active,
-.dark-theme .sort-btn.active {
-  background: var(--cream);
-  color: var(--ink);
-  border-color: var(--cream);
+  background: var(--invert-bg);
+  color: var(--invert-fg);
+  border-color: var(--invert-bg);
 }
 
 .filter-btn.user-filter {
@@ -1831,9 +1835,9 @@ footer {
 }
 
 .modal-nav:hover {
-  background: var(--ink);
-  border-color: var(--ink);
-  color: var(--cream);
+  background: var(--invert-bg);
+  border-color: var(--invert-bg);
+  color: var(--invert-fg);
   transform: translateY(-50%) scale(1.06);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -742,6 +742,24 @@ footer {
   display: block;
 }
 
+/* Fill the wave with the page background so it "scoops" the
+   coloured hero into the section below. Setting fill via CSS
+   instead of an SVG attribute — `fill="var(--…)"` does NOT
+   resolve CSS variables in any browser. */
+.wave-divider svg path {
+  fill: var(--background);
+}
+
+/* Wave anchored at the bottom of the hero section. */
+.hero-wave {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 40px;
+  z-index: 3;
+}
+
 /* ── Global stats section ───────────────────────────────── */
 .global-stats-section {
   padding: 96px 24px;


### PR DESCRIPTION
Brings the YSWS Catalog visually in line with the redesigned hackclub/site same typography, same colors , same hero treatment, same wave dividers, same black footer. All catalog data, filters, search, modals, completion tracking, timeline, and per-program brand art are preserved.
Live demo: https://ysws-catalog.onrender.com/
What changed visually
Typography Phantom Sans (body) + Zarathustra (display) loaded from the Hack Club font CDN, with Outfit + Instrument Serif as Google Fonts fallbacks. Editorial display serif on hero/section headlines; geometric sans for everything else.