### PR TITLE
Make Drafts more visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,8 +356,8 @@
 
         <div class="controls-wrapper">
             <div class="filter-container">
-                <button class="filter-btn" data-category="all">All</button>
-                <button class="filter-btn active" data-category="active" id="filter-btn-active">Active</button>
+                <button class="filter-btn active" data-category="all">All</button>
+                <button class="filter-btn" data-category="active" id="filter-btn-active">Active</button>
                 <button class="filter-btn" data-category="ending-soon">Ending Soon</button>
                 <button class="filter-btn" data-category="draft">Draft</button>
                 <button class="filter-btn" data-category="ended">Ended</button>

--- a/script.js
+++ b/script.js
@@ -93,7 +93,7 @@ async function startRender() {
 
     renderPrograms();
     // Clicks the active filter btn
-    document.getElementById('filter-btn-active').click()
+    document.getElementById('filter-btn-all').click()
     await loadParticipants();
     updateParticipantCounts();
     //console.table(getTimelineEvents()); //DEBUG - PLEASE REMOVE LATER


### PR DESCRIPTION
After the default filter was changed from All to Active, RSVP entries from the ysws site basically disappeared. This PR reverts that change without affecting user experience. The interface remains the same, except users now can scroll down and view the Drafts. Since a lot of new Hack Club members are not aware of the existance of Drafts this helps them discover cool up-and-coming projects.